### PR TITLE
MML-97 Add the Symphony Elements "option" and "select" tags

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -39,9 +39,11 @@ import org.symphonyoss.symphony.messageml.elements.Link;
 import org.symphonyoss.symphony.messageml.elements.ListItem;
 import org.symphonyoss.symphony.messageml.elements.Mention;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
+import org.symphonyoss.symphony.messageml.elements.Option;
 import org.symphonyoss.symphony.messageml.elements.OrderedList;
 import org.symphonyoss.symphony.messageml.elements.Paragraph;
 import org.symphonyoss.symphony.messageml.elements.Preformatted;
+import org.symphonyoss.symphony.messageml.elements.Select;
 import org.symphonyoss.symphony.messageml.elements.Span;
 import org.symphonyoss.symphony.messageml.elements.Table;
 import org.symphonyoss.symphony.messageml.elements.TableBody;
@@ -448,6 +450,12 @@ public class MessageMLParser {
 
       case Form.MESSAGEML_TAG:
         return new Form(parent);
+
+      case Select.MESSAGEML_TAG:
+        return new Select(parent);
+
+      case Option.MESSAGEML_TAG:
+        return new Option(parent);
 
       case Button.MESSAGEML_TAG:
         return new Button(parent);

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * @author lumoura
  * @since 03/21/19
  */
-public class Button extends Element {
+public class Button extends FormElement {
 
   public static final String MESSAGEML_TAG = "button";
   public static final String NAME_ATTR = "name";
@@ -58,13 +58,12 @@ public class Button extends Element {
 
   @Override
   public void validate() throws InvalidInputException {
+    super.validate();
+
     String type = getAttribute(TYPE_ATTR);
     String name = getAttribute(NAME_ATTR);
     String clazz = getAttribute(CLASS_ATTR);
 
-    if (this.getParent().getClass() != Form.class) {
-      throw new InvalidInputException("A \"button\" element can only be a child of a \"form\" element");
-    }
     if (!VALID_TYPES.contains(type)) {
       throw new InvalidInputException("Attribute \"type\" must be \"action\" or \"reset\"");
     }
@@ -75,6 +74,6 @@ public class Button extends Element {
     if (type.equals("action") && StringUtils.isBlank(name)) {
       throw new InvalidInputException("Attribute \"name\" is required for generic action buttons");
     }
-    assertContentModel(Collections.<Class<? extends Element>>singleton(TextNode.class));
+    assertContentModel(Collections.singleton(TextNode.class));
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -348,16 +348,6 @@ public abstract class Element {
   }
 
   /**
-   * Check that the element's allowed parent is limited to one specific element type.
-   */
-  void assertSingleParent(Element permittedParent) throws InvalidInputException {
-    if (!this.getParent().getClass().equals(permittedParent.getClass())) {
-      throw new InvalidInputException(String.format("Element \"%s\" can only be a child of \"%s\"",
-          this.getMessageMLTag(), permittedParent.getMessageMLTag()));
-    }
-  }
-
-  /**
    * Return the element's MessageML tag.
    */
   public String getMessageMLTag() {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -348,6 +348,16 @@ public abstract class Element {
   }
 
   /**
+   * Check that the element's allowed parent is limited to one specific element type.
+   */
+  void assertSingleParent(Element permittedParent) throws InvalidInputException {
+    if (!this.getParent().getClass().equals(permittedParent.getClass())) {
+      throw new InvalidInputException(String.format("Element \"%s\" can only be a child of \"%s\"",
+          this.getMessageMLTag(), permittedParent.getMessageMLTag()));
+    }
+  }
+
+  /**
    * Return the element's MessageML tag.
    */
   public String getMessageMLTag() {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Form.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Form.java
@@ -22,6 +22,6 @@ public class Form extends Element {
   }
 
   /* TODO:  The code for this class is supposed to be implemented in task APP-2055.
-     This class was added here so the code for the Button class (APP-2058) could be complete.
+     This class was added here so the code for the Select class (APP-2056) could be complete.
   */
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/FormElement.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/FormElement.java
@@ -1,0 +1,37 @@
+package org.symphonyoss.symphony.messageml.elements;
+
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class FormElement extends Element {
+  FormElement(Element parent) {
+    super(parent);
+  }
+
+  FormElement(Element parent, String messageMLTag) {
+    super(parent, messageMLTag);
+  }
+
+  FormElement(Element parent, String messageMLTag, FormatEnum format) {
+    super(parent, messageMLTag, format);
+  }
+
+  @Override
+  public void validate() throws InvalidInputException {
+    assertParent(Collections.singleton(Form.class));
+  }
+
+  @Override
+  public void assertParent(Collection<Class<? extends Element>> permittedParents) throws InvalidInputException {
+    if (!permittedParents.contains(this.getParent().getClass())) {
+      String permittedParentsClassAsString = permittedParents.stream()
+          .map(permittedParentClass -> permittedParentClass.getSimpleName().toLowerCase())
+          .reduce((item, anotherItem) -> String.format("%s, %s", item, anotherItem))
+          .orElse("");
+      throw new InvalidInputException(String.format("Element \"%s\" can only be a child of the following elements: \"%s\"",
+          this.getMessageMLTag(), permittedParentsClassAsString));
+    }
+  }
+}

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
@@ -21,16 +21,6 @@ public class Option extends Element {
   }
 
   @Override
-  protected void buildAttribute(org.w3c.dom.Node item) throws InvalidInputException {
-    if (item.getNodeName().equals(VALUE_ATTR)) {
-      setAttribute(VALUE_ATTR, getStringAttribute(item));
-    } else {
-      throw new InvalidInputException("Attribute \"" + item.getNodeName()
-              + "\" is not allowed in \"" + getMessageMLTag() + "\"");
-    }
-  }
-
-  @Override
   public org.commonmark.node.Node asMarkdown() {
     return new OptionNode();
   }
@@ -38,13 +28,21 @@ public class Option extends Element {
 
   @Override
   public void validate() throws InvalidInputException {
-    if (this.getParent().getClass() != Select.class) {
-      throw new InvalidInputException("An \"" + getMessageMLTag() + "\" element can only be a child of a \"" +
-              "select\" element");
-    }
     if (getAttribute(VALUE_ATTR) == null) {
       throw new InvalidInputException("The attribute \"value\" is required");
     }
-    assertContentModel(Collections.<Class<? extends Element>>singleton(TextNode.class));
+
+    assertParent(Collections.singleton(Select.class));
+    assertContentModel(Collections.singleton(TextNode.class));
+  }
+
+  @Override
+  protected void buildAttribute(org.w3c.dom.Node item) throws InvalidInputException {
+    if (item.getNodeName().equals(VALUE_ATTR)) {
+      setAttribute(VALUE_ATTR, getStringAttribute(item));
+    } else {
+      throw new InvalidInputException("Attribute \"" + item.getNodeName()
+          + "\" is not allowed in \"" + getMessageMLTag() + "\"");
+    }
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
@@ -32,7 +32,7 @@ public class Option extends Element {
       throw new InvalidInputException("The attribute \"value\" is required");
     }
 
-    assertParent(Collections.singleton(Select.class));
+    assertSingleParent(new Select(null));
     assertContentModel(Collections.singleton(TextNode.class));
   }
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
@@ -1,0 +1,50 @@
+package org.symphonyoss.symphony.messageml.elements;
+
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.markdown.nodes.OptionNode;
+
+import java.util.Collections;
+
+/**
+ * Class representing a Symphony Elements option
+ *
+ * @author lumoura
+ * @since 03/22/19
+ */
+public class Option extends Element {
+
+  public static final String MESSAGEML_TAG = "option";
+  public static final String VALUE_ATTR = "value";
+
+  public Option(Element parent) {
+    super(parent, MESSAGEML_TAG);
+  }
+
+  @Override
+  protected void buildAttribute(org.w3c.dom.Node item) throws InvalidInputException {
+    if (item.getNodeName().equals(VALUE_ATTR)) {
+      setAttribute(VALUE_ATTR, getStringAttribute(item));
+    } else {
+      throw new InvalidInputException("Attribute \"" + item.getNodeName()
+              + "\" is not allowed in \"" + getMessageMLTag() + "\"");
+    }
+  }
+
+  @Override
+  public org.commonmark.node.Node asMarkdown() {
+    return new OptionNode();
+  }
+
+
+  @Override
+  public void validate() throws InvalidInputException {
+    if (this.getParent().getClass() != Select.class) {
+      throw new InvalidInputException("An \"" + getMessageMLTag() + "\" element can only be a child of a \"" +
+              "select\" element");
+    }
+    if (getAttribute(VALUE_ATTR) == null) {
+      throw new InvalidInputException("The attribute \"value\" is required");
+    }
+    assertContentModel(Collections.<Class<? extends Element>>singleton(TextNode.class));
+  }
+}

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
@@ -3,6 +3,7 @@ package org.symphonyoss.symphony.messageml.elements;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.OptionNode;
 
+import java.util.Collection;
 import java.util.Collections;
 
 /**
@@ -11,7 +12,7 @@ import java.util.Collections;
  * @author lumoura
  * @since 03/22/19
  */
-public class Option extends Element {
+public class Option extends FormElement {
 
   public static final String MESSAGEML_TAG = "option";
   public static final String VALUE_ATTR = "value";
@@ -24,15 +25,13 @@ public class Option extends Element {
   public org.commonmark.node.Node asMarkdown() {
     return new OptionNode();
   }
-
-
   @Override
   public void validate() throws InvalidInputException {
     if (getAttribute(VALUE_ATTR) == null) {
       throw new InvalidInputException("The attribute \"value\" is required");
     }
 
-    assertSingleParent(new Select(null));
+    assertParent(Collections.singleton(Select.class));
     assertContentModel(Collections.singleton(TextNode.class));
   }
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
@@ -52,7 +52,7 @@ public class Select extends Element {
       throw new InvalidInputException("The attribute \"name\" is required");
     }
 
-    assertParent(Collections.singleton(Form.class));
+    assertSingleParent(new Form(null));
     assertContentModel(Collections.singleton(Option.class));
     assertAtLeastOneOptionChild();
     validateRequiredAttribute(getAttribute(REQUIRED_ATTR));
@@ -86,7 +86,7 @@ public class Select extends Element {
 
   private void validateRequiredAttribute(String requiredAttrValue) throws InvalidInputException {
     if (requiredAttrValue != null && !VALID_VALUES_FOR_REQUIRED_ATTR.contains(requiredAttrValue)) {
-      throw new InvalidInputException(String.format("Attribute \"%s\" must be one of the following values (%s)",
+      throw new InvalidInputException(String.format("Attribute \"%s\" must have one of the following values: %s",
           REQUIRED_ATTR, VALID_VALUES_FOR_REQUIRED_ATTR));
     }
   }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
@@ -19,7 +19,10 @@ package org.symphonyoss.symphony.messageml.elements;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.SelectNode;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Class representing dropdown menu - Symphony Elements.
@@ -30,11 +33,29 @@ import java.util.Collections;
 public class Select extends Element {
 
   public static final String MESSAGEML_TAG = "select";
-  public static final String NAME_ATTR = "name";
-  public static final String REQUIRED_ATTR = "required";
+  private static final String NAME_ATTR = "name";
+  private static final String REQUIRED_ATTR = "required";
+  private static final Set<String> VALID_VALUES_FOR_REQUIRED_ATTR = new HashSet<>(Arrays.asList("true", "false"));
 
   public Select(Element parent) {
     super(parent, MESSAGEML_TAG);
+  }
+
+  @Override
+  public org.commonmark.node.Node asMarkdown() {
+    return new SelectNode(getAttribute(NAME_ATTR));
+  }
+
+  @Override
+  public void validate() throws InvalidInputException {
+    if (getAttribute(NAME_ATTR) == null) {
+      throw new InvalidInputException("The attribute \"name\" is required");
+    }
+
+    assertParent(Collections.singleton(Form.class));
+    assertContentModel(Collections.singleton(Option.class));
+    assertAtLeastOneOptionChild();
+    validateRequiredAttribute(getAttribute(REQUIRED_ATTR));
   }
 
   @Override
@@ -43,48 +64,30 @@ public class Select extends Element {
       case NAME_ATTR:
         setAttribute(NAME_ATTR, getStringAttribute(item));
         break;
-
       case REQUIRED_ATTR:
-        String requiredAttrValue = getStringAttribute(item).toLowerCase();
-        if (requiredAttrValue.equals("true")) {
-          setAttribute(REQUIRED_ATTR, "true");
-        } else if (!requiredAttrValue.equals("false")) {
-          throw new InvalidInputException("Attribute \"" + REQUIRED_ATTR + "\" must be either \"true\" or \"false\"");
-        }
+        setAttribute(REQUIRED_ATTR, getStringAttribute(item));
         break;
-
       default:
         throw new InvalidInputException("Attribute \"" + item.getNodeName()
-                + "\" is not allowed in \"" + getMessageMLTag() + "\"");
+            + "\" is not allowed in \"" + getMessageMLTag() + "\"");
     }
-  }
-
-  @Override
-  public org.commonmark.node.Node asMarkdown() {
-    return new SelectNode(getAttribute(NAME_ATTR));
   }
 
   private void assertAtLeastOneOptionChild() throws InvalidInputException {
-    if (this.getChildren().size() == 0) {
-      throw new InvalidInputException("The \"" + getMessageMLTag() + "\" element must have at least one \""
-              + Option.MESSAGEML_TAG + "\" as its child.");
-    }
-    if (this.getChildren().size() == 1 && this.getChildren().get(0).getClass() == TextNode.class) {
-      throw new InvalidInputException("The \"" + getMessageMLTag() + "\" element must have at least one \""
-              + Option.MESSAGEML_TAG + "\" as its child.");
+    boolean hasOptionElementAsChild = this.getChildren()
+        .stream()
+        .anyMatch(child -> child.getClass().equals(Option.class));
+
+    if (!hasOptionElementAsChild) {
+      throw new InvalidInputException(String.format("The \"%s\" element must have at least one \"%s\" as its child.",
+          MESSAGEML_TAG, Option.MESSAGEML_TAG));
     }
   }
 
-  @Override
-  public void validate() throws InvalidInputException {
-    if (this.getParent().getClass() != Form.class) {
-      throw new InvalidInputException("A \"" + getMessageMLTag() + "\" element can only be a child of a \"" +
-              "form\" element");
+  private void validateRequiredAttribute(String requiredAttrValue) throws InvalidInputException {
+    if (requiredAttrValue != null && !VALID_VALUES_FOR_REQUIRED_ATTR.contains(requiredAttrValue)) {
+      throw new InvalidInputException(String.format("Attribute \"%s\" must be one of the following values (%s)",
+          REQUIRED_ATTR, VALID_VALUES_FOR_REQUIRED_ATTR));
     }
-    if (getAttribute(NAME_ATTR) == null) {
-      throw new InvalidInputException("The attribute \"name\" is required");
-    }
-    assertAtLeastOneOptionChild();
-    assertContentModel(Collections.<Class<? extends Element>>singleton(Option.class));
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016-2017 MessageML - Symphony LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.symphonyoss.symphony.messageml.elements;
+
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.markdown.nodes.SelectNode;
+
+import java.util.Collections;
+
+/**
+ * Class representing dropdown menu - Symphony Elements.
+ *
+ * @author lumoura
+ * @since 3/22/18
+ */
+public class Select extends Element {
+
+  public static final String MESSAGEML_TAG = "select";
+  public static final String NAME_ATTR = "name";
+  public static final String REQUIRED_ATTR = "required";
+
+  public Select(Element parent) {
+    super(parent, MESSAGEML_TAG);
+  }
+
+  @Override
+  protected void buildAttribute(org.w3c.dom.Node item) throws InvalidInputException {
+    switch (item.getNodeName()) {
+      case NAME_ATTR:
+        setAttribute(NAME_ATTR, getStringAttribute(item));
+        break;
+
+      case REQUIRED_ATTR:
+        String requiredAttrValue = getStringAttribute(item).toLowerCase();
+        if (requiredAttrValue.equals("true")) {
+          setAttribute(REQUIRED_ATTR, "true");
+        } else if (!requiredAttrValue.equals("false")) {
+          throw new InvalidInputException("Attribute \"" + REQUIRED_ATTR + "\" must be either \"true\" or \"false\"");
+        }
+        break;
+
+      default:
+        throw new InvalidInputException("Attribute \"" + item.getNodeName()
+                + "\" is not allowed in \"" + getMessageMLTag() + "\"");
+    }
+  }
+
+  @Override
+  public org.commonmark.node.Node asMarkdown() {
+    return new SelectNode(getAttribute(NAME_ATTR));
+  }
+
+  private void assertAtLeastOneOptionChild() throws InvalidInputException {
+    if (this.getChildren().size() == 0) {
+      throw new InvalidInputException("The \"" + getMessageMLTag() + "\" element must have at least one \""
+              + Option.MESSAGEML_TAG + "\" as its child.");
+    }
+    if (this.getChildren().size() == 1 && this.getChildren().get(0).getClass() == TextNode.class) {
+      throw new InvalidInputException("The \"" + getMessageMLTag() + "\" element must have at least one \""
+              + Option.MESSAGEML_TAG + "\" as its child.");
+    }
+  }
+
+  @Override
+  public void validate() throws InvalidInputException {
+    if (this.getParent().getClass() != Form.class) {
+      throw new InvalidInputException("A \"" + getMessageMLTag() + "\" element can only be a child of a \"" +
+              "form\" element");
+    }
+    if (getAttribute(NAME_ATTR) == null) {
+      throw new InvalidInputException("The attribute \"name\" is required");
+    }
+    assertAtLeastOneOptionChild();
+    assertContentModel(Collections.<Class<? extends Element>>singleton(Option.class));
+  }
+}

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
@@ -20,6 +20,7 @@ import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.SelectNode;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -30,7 +31,7 @@ import java.util.Set;
  * @author lumoura
  * @since 3/22/18
  */
-public class Select extends Element {
+public class Select extends FormElement {
 
   public static final String MESSAGEML_TAG = "select";
   private static final String NAME_ATTR = "name";
@@ -48,11 +49,12 @@ public class Select extends Element {
 
   @Override
   public void validate() throws InvalidInputException {
+    super.validate();
+
     if (getAttribute(NAME_ATTR) == null) {
       throw new InvalidInputException("The attribute \"name\" is required");
     }
 
-    assertSingleParent(new Form(null));
     assertContentModel(Collections.singleton(Option.class));
     assertAtLeastOneOptionChild();
     validateRequiredAttribute(getAttribute(REQUIRED_ATTR));

--- a/src/main/java/org/symphonyoss/symphony/messageml/markdown/MarkdownRenderer.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/markdown/MarkdownRenderer.java
@@ -38,7 +38,17 @@ import org.commonmark.node.StrongEmphasis;
 import org.commonmark.node.Text;
 import org.commonmark.renderer.text.TextContentWriter;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
-import org.symphonyoss.symphony.messageml.markdown.nodes.*;
+import org.symphonyoss.symphony.messageml.markdown.nodes.ButtonNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.EmojiNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.FormNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.KeywordNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.MentionNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.OptionNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.PreformattedNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.SelectNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.TableCellNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.TableNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.TableRowNode;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 
 import java.util.Collection;

--- a/src/main/java/org/symphonyoss/symphony/messageml/markdown/MarkdownRenderer.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/markdown/MarkdownRenderer.java
@@ -38,15 +38,7 @@ import org.commonmark.node.StrongEmphasis;
 import org.commonmark.node.Text;
 import org.commonmark.renderer.text.TextContentWriter;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
-import org.symphonyoss.symphony.messageml.markdown.nodes.ButtonNode;
-import org.symphonyoss.symphony.messageml.markdown.nodes.EmojiNode;
-import org.symphonyoss.symphony.messageml.markdown.nodes.FormNode;
-import org.symphonyoss.symphony.messageml.markdown.nodes.KeywordNode;
-import org.symphonyoss.symphony.messageml.markdown.nodes.MentionNode;
-import org.symphonyoss.symphony.messageml.markdown.nodes.PreformattedNode;
-import org.symphonyoss.symphony.messageml.markdown.nodes.TableCellNode;
-import org.symphonyoss.symphony.messageml.markdown.nodes.TableNode;
-import org.symphonyoss.symphony.messageml.markdown.nodes.TableRowNode;
+import org.symphonyoss.symphony.messageml.markdown.nodes.*;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 
 import java.util.Collection;
@@ -238,6 +230,8 @@ public class MarkdownRenderer extends AbstractVisitor {
       visit((EmojiNode) node);
     } else if (node instanceof MentionNode) {
       visit((MentionNode) node);
+    } else if (node instanceof OptionNode) {
+      visit((OptionNode) node);
     }
   }
 
@@ -255,6 +249,8 @@ public class MarkdownRenderer extends AbstractVisitor {
       visit((FormNode) node);
     } else if (node instanceof ButtonNode) {
       visit((ButtonNode) node);
+    } else if (node instanceof SelectNode) {
+      visit((SelectNode) node);
     }
   }
 
@@ -262,6 +258,19 @@ public class MarkdownRenderer extends AbstractVisitor {
     writer.write(emoji.getOpeningDelimiter());
     writer.write(emoji.getShortcode());
     writer.write(emoji.getClosingDelimiter());
+  }
+
+  private void visit(SelectNode select){
+    writer.write(select.getOpeningDelimiter());
+    writer.write(select.getName());
+    writer.write(select.getClosingDelimiter());
+    visitChildren(select);
+  }
+
+  private void visit(OptionNode option) {
+    writer.write(option.getOpeningDelimiter());
+    visitChildren(option);
+    writer.write(option.getClosingDelimiter());
   }
 
   private void visit(KeywordNode keyword) {

--- a/src/main/java/org/symphonyoss/symphony/messageml/markdown/nodes/OptionNode.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/markdown/nodes/OptionNode.java
@@ -1,0 +1,25 @@
+package org.symphonyoss.symphony.messageml.markdown.nodes;
+
+import org.commonmark.node.CustomNode;
+import org.commonmark.node.Delimited;
+import org.commonmark.node.Visitor;
+
+public class OptionNode extends CustomNode implements Delimited {
+  private final static String LEFT_DELIMITER = "-";
+  private final static String RIGHT_DELIMITER = "";
+
+  @Override
+  public String getOpeningDelimiter() {
+    return LEFT_DELIMITER;
+  }
+
+  @Override
+  public String getClosingDelimiter() {
+    return RIGHT_DELIMITER + "\n";
+  }
+
+  @Override
+  public void accept(Visitor visitor) {
+    visitor.visit(this);
+  }
+}

--- a/src/main/java/org/symphonyoss/symphony/messageml/markdown/nodes/SelectNode.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/markdown/nodes/SelectNode.java
@@ -1,0 +1,31 @@
+package org.symphonyoss.symphony.messageml.markdown.nodes;
+
+import org.commonmark.node.CustomBlock;
+
+public class SelectNode extends CustomBlock {
+  private final static String LEAD = "Dropdown:";
+  private final static String LEFT_DELIMITER = "(";
+  private final static String RIGHT_DELIMITER = "):";
+
+  private String name;
+
+  public SelectNode(String name) {
+    this.name = name;
+  }
+
+  public String getOpeningDelimiter() {
+    return LEFT_DELIMITER + LEAD;
+  }
+
+  public String getClosingDelimiter() {
+    return RIGHT_DELIMITER + "\n";
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/ButtonTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/ButtonTest.java
@@ -134,7 +134,7 @@ public class ButtonTest extends ElementTest{
       fail("Should have thrown an exception on button out of a form tag");
     } catch (Exception e) {
       assertEquals("Exception class", InvalidInputException.class, e.getClass());
-      assertEquals("Exception message", "A \"button\" element can only be a child of a \"form\" element", e.getMessage());
+      assertEquals("Exception message", "Element \"button\" can only be a child of the following elements: \"form\"", e.getMessage());
     }
   }
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/SelectOptionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/SelectOptionTest.java
@@ -164,7 +164,7 @@ public class SelectOptionTest extends ElementTest {
     String input = "<messageML><option value=\"\">Option 1</option></messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("Element \"option\" is not allowed as a child of \"messageML\"");
+    expectedException.expectMessage("Element \"option\" can only be a child of \"select\"");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/SelectOptionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/SelectOptionTest.java
@@ -154,7 +154,7 @@ public class SelectOptionTest extends ElementTest {
     String input = "<messageML><select name=\"" + name + "\"><option value=\"\">Option 1</option></select></messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("Element \"select\" can only be a child of \"form\"");
+    expectedException.expectMessage("Element \"select\" can only be a child of the following elements: \"form\"");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
@@ -164,7 +164,7 @@ public class SelectOptionTest extends ElementTest {
     String input = "<messageML><option value=\"\">Option 1</option></messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("Element \"option\" can only be a child of \"select\"");
+    expectedException.expectMessage("Element \"option\" can only be a child of the following elements: \"select\"");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/SelectOptionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/SelectOptionTest.java
@@ -1,0 +1,239 @@
+package org.symphonyoss.symphony.messageml.elements;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+
+public class SelectOptionTest extends ElementTest{
+
+  @Test
+  public void testCompleteRequiredSelect() throws Exception {
+    String name = "complete-required-id";
+    boolean required = true;
+    String input = "<messageML><form><select name=\"" + name + "\" required=\"" + required +
+            "\"><option value=\"\">Option 1</option></select></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    Element form = messageML.getChildren().get(0);
+    Element select = form.getChildren().get(0);
+
+    assertEquals("Select class", Select.class, select.getClass());
+    verifySelectPresentation((Select) select, name, required);
+  }
+
+  @Test
+  public void testCompleteNotRequiredSelect() throws Exception {
+    String name = "complete-id";
+    boolean required = false;
+    String input = "<messageML><form><select name=\"" + name + "\" required=\"" + required +
+            "\"><option value=\"\">Option 1</option></select></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    Element form = messageML.getChildren().get(0);
+    Element select = form.getChildren().get(0);
+
+    assertEquals("Select class", Select.class, select.getClass());
+    verifySelectPresentation((Select) select, name, required);
+  }
+
+  @Test
+  public void testSimpleSelect() throws Exception {
+    String name = "simple-id";
+    String input = "<messageML><form><select name=\"" + name + "\"><option value=\"\">Option 1</option></select></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    Element form = messageML.getChildren().get(0);
+    Element select = form.getChildren().get(0);
+
+    assertEquals("Select class", Select.class, select.getClass());
+    verifySelectPresentation((Select) select, name, false);
+  }
+
+  @Test
+  public void testDoubleOptionSelect() throws Exception {
+    String name = "simple-id";
+    String input = "<messageML><form><select name=\"" + name + "\"><option value=\"1\">Option 1</option><option value=\"2\">" +
+            "Option 2</option></select></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    Element form = messageML.getChildren().get(0);
+    Element select = form.getChildren().get(0);
+
+    assertEquals("Select class", Select.class, select.getClass());
+    verifySelectPresentation((Select) select, name, false);
+  }
+
+  @Test
+  public void testChildlessSelect() throws Exception {
+    String name = "childless-select";
+    String input = "<messageML><form><select name=\"" + name + "\"></select></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The \"select\" element must have at least one \"option\" as its child.");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testSelectWithEmptyChild() throws Exception {
+    String name = "empty-child-select";
+    String input = "<messageML><form><select name=\"" + name + "\"> </select></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The \"select\" element must have at least one \"option\" as its child.");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testSelectWithoutName() throws Exception {
+    String input = "<messageML><form><select><option value=\"\">Option 1</option></select></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The attribute \"name\" is required");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testOptionWithoutValue() throws Exception {
+    String name = "nameless-option";
+    String input = "<messageML><form><select name=\"" + name +"\"><option>Option 1</option></select></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The attribute \"value\" is required");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testSelectWithInvalidRequiredAttribute() throws Exception {
+    String name = "invalid-required-select";
+    String input = "<messageML><form><select name=\"" + name + "\" required=\"potato\"><option value=\"\">Option 1</option></select></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"required\" must be either \"true\" or \"false\"");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testSelectWithInvalidAttribute() throws Exception {
+    String name = "invalid-attribute-select";
+    String input = "<messageML><form><select name=\"" + name + "\"  invalid=\"attribute\"><option value=\"\">Option 1</option></select></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"invalid\" is not allowed in \"select\"");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testOptionWithInvalidAttribute() throws Exception {
+    String name = "invalid-attribute-option";
+    String input = "<messageML><form><select name=\"" + name + "\"><option value=\"\" invalid=\"attribute\">Option 1</option></select></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"invalid\" is not allowed in \"option\"");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testSelectOutOfForm() throws Exception {
+    String name = "out-of-form-select";
+    String input = "<messageML><select name=\"" + name + "\"><option value=\"\">Option 1</option></select></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("A \"select\" element can only be a child of a \"form\" element");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testOptionOutOfSelect() throws Exception {
+    String input = "<messageML><option value=\"\">Option 1</option></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("An \"option\" element can only be a child of a \"select\" element");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testSelectWithInvalidChild() throws Exception {
+    String name = "invalid-child-select";
+    String input = "<messageML><form><select name=\"" + name + "\"><span></span></select></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Element \"span\" is not allowed in \"select\"");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testOptionWithInvalidChild() throws Exception {
+    String name = "invalid-child-option";
+    String input = "<messageML><form><select name=\"" + name + "\"><option value=\"\"><span></span></option></select></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Element \"span\" is not allowed in \"option\"");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  private String getRequiredPresentationML(String required) {
+    if (required != null && required.equals("true")) {
+      return " required=\"true\"";
+    } else {
+      return "";
+    }
+  }
+
+  private String getExpectedSelectMarkdown(Select select) {
+    String FORM_MARKDOWN_HEADER = "Form (log into desktop client to answer):\n---\n";
+    String FORM_MARKDOWN_FOOTER = "---\n";
+    String selectMarkdown = "(Dropdown:" + select.getAttribute(Select.NAME_ATTR) + "):\n";
+
+    for (Element option : select.getChildren()) {
+      if (option instanceof Option) {
+        selectMarkdown = selectMarkdown + "-" + option.getChild(0).asText() + "\n";
+      }
+    }
+    return FORM_MARKDOWN_HEADER + selectMarkdown + "\n" + FORM_MARKDOWN_FOOTER;
+  }
+
+  private String getExpectedSelectPresentation(Select select) {
+    String selectOpeningTag = "<div data-format=\"PresentationML\" data-version=\"2.0\"><form><select name=\"" +
+            select.getAttribute(Select.NAME_ATTR) + "\"" + getRequiredPresentationML(select.getAttribute(Select.REQUIRED_ATTR)) + ">";
+    String selectClosingTag = "</select></form></div>";
+    String selectChildren = "";
+
+    for (Element option : select.getChildren()) {
+      if (option instanceof Option) {
+        selectChildren = selectChildren + "<option value=\"" + option.getAttribute(Option.VALUE_ATTR) + "\">" +
+                option.getChild(0).asText() + "</option>";
+      }
+    }
+    return selectOpeningTag + selectChildren + selectClosingTag;
+  }
+
+  private void verifySelectPresentation(Select select, String name, boolean required) {
+    assertEquals("Select name attribute", name, select.getAttribute(Select.NAME_ATTR));
+    if (required) {
+      assertEquals("Select required attribute", "true", select.getAttribute(Select.REQUIRED_ATTR));
+    } else {
+      assertNull("Select required attribute", select.getAttribute(Select.REQUIRED_ATTR));
+    }
+
+    assertEquals("Select presentationML", getExpectedSelectPresentation(select),
+            context.getPresentationML());
+    assertEquals("Select markdown", getExpectedSelectMarkdown(select), context.getMarkdown());
+  }
+}


### PR DESCRIPTION
Problem: We need to support new Symphony Elements tag Select, that represents a dropdown menu.
Solution: Added the messageml validation and parsing into presentationml and markdown of the <select> and <option> tags. The validation assures the defined restrictions of the tag. Unit tests for the select tag were also added.