### PR TITLE
MML-142 - elements with required 'id' or 'name' attributes shouldn't allow blank values

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -75,6 +75,7 @@ public class Button extends FormElement {
     if (type.equals("reset") && getAttributes().containsKey(NAME_ATTR)) {
       throw new InvalidInputException("Attribute \"name\" is allowed for generic action buttons only");
     }
+    
     assertContentModel(Collections.singleton(TextNode.class));
     assertContainsChildOfType(Collections.singleton(TextNode.class));
   }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -72,6 +72,9 @@ public class Button extends FormElement {
     if (type.equals("action") && StringUtils.isBlank(name)) {
       throw new InvalidInputException("Attribute \"name\" is required for generic action buttons");
     }
+    if (type.equals("reset") && getAttributes().containsKey(NAME_ATTR)) {
+      throw new InvalidInputException("Attribute \"name\" is allowed for generic action buttons only");
+    }
     assertContentModel(Collections.singleton(TextNode.class));
     assertContainsChildOfType(Collections.singleton(TextNode.class));
   }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -70,12 +70,12 @@ public class Button extends FormElement {
               "\"primary-destructive\" or \"secondary-destructive\"");
     }
     if (type.equals("action") && StringUtils.isBlank(name)) {
-      throw new InvalidInputException("Attribute \"name\" is required for generic action buttons");
+      throw new InvalidInputException("Attribute \"name\" is required for action buttons");
     }
     if (type.equals("reset") && getAttributes().containsKey(NAME_ATTR)) {
-      throw new InvalidInputException("Attribute \"name\" is allowed for generic action buttons only");
+      throw new InvalidInputException("Attribute \"name\" is allowed for action buttons only");
     }
-    
+
     assertContentModel(Collections.singleton(TextNode.class));
     assertContainsChildOfType(Collections.singleton(TextNode.class));
   }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Checkbox.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Checkbox.java
@@ -71,7 +71,9 @@ public class Checkbox extends FormElement {
 
     if (!getChildren().isEmpty()) {
       assertContentModel(Arrays.asList(TextNode.class, Bold.class, Italic.class));
-    }    
+    }
+
+    assertAttributeNotBlank(NAME_ATTR);
   }
 
   @Override

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Form.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Form.java
@@ -27,6 +27,8 @@ public class Form extends Element {
     if (getAttribute(ID_ATTR) == null) {
       throw new InvalidInputException("The attribute \"id\" is required");
     }
+
+    assertAttributeNotBlank(ID_ATTR);
   }
 
   @Override

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/PersonSelector.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/PersonSelector.java
@@ -68,6 +68,7 @@ public class PersonSelector extends FormElement {
     }
     
     assertNoContent();
+    assertAttributeNotBlank(NAME_ATTR);
   }
 
   @Override

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
@@ -61,6 +61,7 @@ public class Select extends FormElement {
     }
 
     assertOnlyOneOptionSelected();
+    assertAttributeNotBlank(NAME_ATTR);
   }
 
   @Override

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TextArea.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TextArea.java
@@ -39,6 +39,7 @@ public class TextArea extends FormElement {
       assertAttributeValue(REQUIRED_ATTR, VALID_VALUES_FOR_REQUIRED_ATTR);
     }
 
+    assertAttributeNotBlank(NAME_ATTR);
     assertContentModel(Collections.singleton(TextNode.class));
   }
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TextField.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TextField.java
@@ -62,6 +62,7 @@ public class TextField extends FormElement {
     }
 
     validateMinAndMaxLengths();
+    assertAttributeNotBlank(NAME_ATTR);
     assertContentModel(Collections.singleton(TextNode.class));
   }
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
@@ -139,6 +139,36 @@ public class ButtonTest extends ElementTest {
   }
 
   @Test
+  public void testActionButtonWithBlankName() throws Exception {
+    String type = "action";
+    String innerText = "Typeless Button Without Name";
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + type + "\" name=\" \">" + innerText + "</button></form></messageML>";
+
+    try {
+      context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+      fail("Should have thrown an exception on action button without name");
+    } catch (Exception e) {
+      assertEquals("Exception class", InvalidInputException.class, e.getClass());
+      assertEquals("Exception message", "Attribute \"name\" is required for generic action buttons", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testResetButtonWithName() throws Exception {
+    String type = "reset";
+    String innerText = "Reset";
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + type + "\" name=\" \">" + innerText + "</button></form></messageML>";
+
+    try {
+      context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+      fail("Should have thrown an exception on action button without name");
+    } catch (Exception e) {
+      assertEquals("Exception class", InvalidInputException.class, e.getClass());
+      assertEquals("Exception message", "Attribute \"name\" is allowed for generic action buttons only", e.getMessage());
+    }
+  }
+
+  @Test
   public void testActionButtonWithoutTextNode() throws Exception {
     String type = "action";
     String name = "btn-name";

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
@@ -119,7 +119,7 @@ public class ButtonTest extends ElementTest {
       fail("Should have thrown an exception on typeless button without name");
     } catch (Exception e) {
       assertEquals("Exception class", InvalidInputException.class, e.getClass());
-      assertEquals("Exception message", "Attribute \"name\" is required for generic action buttons", e.getMessage());
+      assertEquals("Exception message", "Attribute \"name\" is required for action buttons", e.getMessage());
     }
   }
 
@@ -134,7 +134,7 @@ public class ButtonTest extends ElementTest {
       fail("Should have thrown an exception on action button without name");
     } catch (Exception e) {
       assertEquals("Exception class", InvalidInputException.class, e.getClass());
-      assertEquals("Exception message", "Attribute \"name\" is required for generic action buttons", e.getMessage());
+      assertEquals("Exception message", "Attribute \"name\" is required for action buttons", e.getMessage());
     }
   }
 
@@ -149,7 +149,7 @@ public class ButtonTest extends ElementTest {
       fail("Should have thrown an exception on action button without name");
     } catch (Exception e) {
       assertEquals("Exception class", InvalidInputException.class, e.getClass());
-      assertEquals("Exception message", "Attribute \"name\" is required for generic action buttons", e.getMessage());
+      assertEquals("Exception message", "Attribute \"name\" is required for action buttons", e.getMessage());
     }
   }
 
@@ -164,7 +164,7 @@ public class ButtonTest extends ElementTest {
       fail("Should have thrown an exception on action button without name");
     } catch (Exception e) {
       assertEquals("Exception class", InvalidInputException.class, e.getClass());
-      assertEquals("Exception message", "Attribute \"name\" is allowed for generic action buttons only", e.getMessage());
+      assertEquals("Exception message", "Attribute \"name\" is allowed for action buttons only", e.getMessage());
     }
   }
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/CheckboxTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/CheckboxTest.java
@@ -177,6 +177,16 @@ public class CheckboxTest extends ElementTest {
   }
 
   @Test
+  public void testCheckboxWithBlankName() throws Exception {
+    String input = buildMessageMLFromParameters(" ", value, text, checked, true);
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The attribute \"name\" is required");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testCheckboxWithoutAny() throws Exception {
     String input = buildMessageMLFromParameters(null, null, null, "false", false);
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/FormTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/FormTest.java
@@ -35,6 +35,16 @@ public class FormTest extends ElementTest {
   }
 
   @Test
+  public void testFormWithBlankId() throws Exception {
+    String input = "<messageML><form id=\" \"></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The attribute \"id\" is required");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testFormWithInvalidAttribute() throws Exception {
     String id = "invalid-attribute-form";
     String input = "<messageML><form id=\"" + id + "\" invalid=\"true\"></form></messageML>";

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/PersonSelectorTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/PersonSelectorTest.java
@@ -69,6 +69,14 @@ public class PersonSelectorTest extends ElementTest {
   }
 
   @Test
+  public void sendPersonSelectorWithBlankName() throws Exception {
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The attribute \"name\" is required");
+    context.parseMessageML("<messageML><form id=\"" + FORM_ID_ATTR + "\"><person-selector name=\" \"></person-selector></form></messageML>", null, MessageML.MESSAGEML_VERSION);
+  }
+
+
+  @Test
   public void sendPersonSelectorOutsideForm() throws Exception {
     context.parseMessageML("<messageML><form id=\"" + FORM_ID_ATTR + "\"><div><person-selector name=\"some-name\"/></div></form></messageML>", null, MessageML.MESSAGEML_VERSION);
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/RadioTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/RadioTest.java
@@ -329,6 +329,18 @@ public class RadioTest extends ElementTest {
   }
 
   @Test
+  public void testRadioWithBlankName() throws Exception {
+    StringBuilder input = new StringBuilder("<messageML><form id=\"" + formId + "\">");
+    input.append("<radio value=\"value01\" name=\" \">First</radio>");
+    input.append("</form></messageML>");
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The attribute \"name\" is required");
+
+    context.parseMessageML(input.toString(), null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testRadioWithoutAny() throws Exception {
     StringBuilder input = new StringBuilder("<messageML><form id=\"" + formId + "\">");
     input.append("<radio></radio>");

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/SelectOptionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/SelectOptionTest.java
@@ -154,6 +154,16 @@ public class SelectOptionTest extends ElementTest {
   }
 
   @Test
+  public void testSelectWithBlankName() throws Exception {
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><select name=\" \"><option value=\"\">Option 1</option></select></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The attribute \"name\" is required");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testOptionWithoutValue() throws Exception {
     String name = "nameless-option";
     String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><select name=\"" + name +"\"><option>Option 1</option></select></form></messageML>";

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextAreaTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextAreaTest.java
@@ -132,6 +132,16 @@ public class TextAreaTest extends ElementTest {
   }
 
   @Test
+  public void testTextAreaWithBlankName() throws Exception {
+    String input = "<messageML><form id=\"form-id\"><textarea name=\" \"></textarea></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The attribute \"name\" is required");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testTextAreaWithInvalidRequiredAttributeValue() throws Exception {
     String input = String.format("<messageML><form id=\"form-id\"><textarea name=\"%s\" required=\"value\"></textarea></form></messageML>", NAME_VALUE);
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
@@ -364,6 +364,16 @@ public class TextFieldTest extends ElementTest {
   }
 
   @Test
+  public void testTextFieldWithBlankName() throws Exception {
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><text-field name=\" \"/></form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The attribute \"name\" is required");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testRequiredTextFieldWithInvalidValue() throws Exception {
     String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><text-field name=\"invalid-required\" required=\"invalidRequired\"/></form></messageML>";
 


### PR DESCRIPTION
Fixes https://github.com/symphonyoss/messageml-utils/issues/142.

I also added unit tests for the elements (radio and action buttons) which are not currently failing.