### PR TITLE
MML-145 - Validate maxlength and minlength on initial value for text-field attribute

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TextField.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TextField.java
@@ -1,5 +1,7 @@
 package org.symphonyoss.symphony.messageml.elements;
 
+import static java.lang.String.format;
+
 import org.symphonyoss.symphony.messageml.MessageMLParser;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
@@ -62,7 +64,6 @@ public class TextField extends FormElement {
     }
 
     assertAttributeNotBlank(NAME_ATTR);
-    // guarantees that we will only have one children and its the expected type: TextNode
     assertContentModel(Collections.singleton(TextNode.class));
     validateMinAndMaxLengths();
   }
@@ -200,39 +201,52 @@ public class TextField extends FormElement {
 
   private void validateMinAndMaxLengths() throws InvalidInputException {
     Integer maxLength = getAttributeAsInteger(MAXLENGTH_ATTR);
-    if (isLengthIsOutOfRange(maxLength)) {
+    if (isLengthOutOfRange(maxLength)) {
       throw new InvalidInputException(getLengthErrorMessage(MAXLENGTH_ATTR));
     }
 
     Integer minLength = getAttributeAsInteger(MINLENGTH_ATTR);
-    if (isLengthIsOutOfRange(minLength)) {
+    if (isLengthOutOfRange(minLength)) {
       throw new InvalidInputException(getLengthErrorMessage(MINLENGTH_ATTR));
     }
 
-    if (minLength != null && maxLength != null && minLength > maxLength) {
+    minLength = getDefaultValueIfCurrentIsNull(minLength, MIN_ALLOWED_LENGTH);
+    maxLength = getDefaultValueIfCurrentIsNull(maxLength, MAX_ALLOWED_LENGTH);
+
+    if (isMinAndMaxLengthCombinationValid(maxLength, minLength)) {
       throw new InvalidInputException("The attribute \"minlength\" must be lower than the \"maxlength\" attribute");
     }
-    if (hasInitialValue()) {
-      TextNode initialValueElement = (TextNode) getChild(0);
-      String initialValue = initialValueElement.getText();
-      if (initialValue != null) {
-        if (isTextSmallerThanMinLength(minLength, initialValue) || isTextBiggerThanMaxLength(maxLength, initialValue)) {
-          throw new InvalidInputException(
-              "The initial value of a text field must respect the minlength and maxlength set on its element");
-        }
+
+    if (textFieldHasInitialValue()) {
+      String initialValue = getTextFieldInitialValue();
+      if (isTextSmallerThanMinLength(minLength, initialValue) || isTextBiggerThanMaxLength(maxLength, initialValue)) {
+        throw new InvalidInputException(
+            format("The length of a text-field's initial value must be between %s and %s", minLength, maxLength));
       }
     }
   }
 
+  private Integer getDefaultValueIfCurrentIsNull(Integer currentValue, Integer defaultValue) {
+    return currentValue == null ? defaultValue : currentValue;
+  }
+
+  private String getTextFieldInitialValue() {
+    return ((TextNode) getChild(0)).getText();
+  }
+
+  private boolean isMinAndMaxLengthCombinationValid(Integer maxLength, Integer minLength) {
+    return minLength != null && maxLength != null && minLength > maxLength;
+  }
+
   private boolean isTextBiggerThanMaxLength(Integer maxLength, String text) {
-    return maxLength != null && text.length() > maxLength;
+    return text != null && maxLength != null && text.length() > maxLength;
   }
 
   private boolean isTextSmallerThanMinLength(Integer minLength, String text) {
-    return minLength != null && text.length() < minLength;
+    return text != null && minLength != null && text.length() < minLength;
   }
 
-  private boolean hasInitialValue() {
+  private boolean textFieldHasInitialValue() {
     return getChildren() != null && getChildren().size() == 1 && getChild(0) instanceof TextNode;
   }
 
@@ -243,19 +257,19 @@ public class TextField extends FormElement {
       try {
         length = Integer.parseInt(getAttribute(attributeName));
       } catch (NumberFormatException e) {
-        throw new InvalidInputException(String.format("The attribute \"%s\" must be a valid number.", attributeName));
+        throw new InvalidInputException(format("The attribute \"%s\" must be a valid number.", attributeName));
       }
     }
 
     return length;
   }
 
-  private boolean isLengthIsOutOfRange(Integer length) {
+  private boolean isLengthOutOfRange(Integer length) {
     return length != null && (length < MIN_ALLOWED_LENGTH || length > MAX_ALLOWED_LENGTH);
   }
 
   private String getLengthErrorMessage(String attributeName) {
-    return String.format("The attribute \"%s\" must be between %s and %s", attributeName, MIN_ALLOWED_LENGTH, MAX_ALLOWED_LENGTH);
+    return format("The attribute \"%s\" must be between %s and %s", attributeName, MIN_ALLOWED_LENGTH, MAX_ALLOWED_LENGTH);
   }
 
 }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
@@ -314,7 +314,7 @@ public class TextFieldTest extends ElementTest {
         + "</messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+    expectedException.expectMessage("The length of a text-field's initial value must be between 1 and 5");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
@@ -328,7 +328,7 @@ public class TextFieldTest extends ElementTest {
         + "</messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+    expectedException.expectMessage("The length of a text-field's initial value must be between 20 and 128");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
@@ -342,7 +342,7 @@ public class TextFieldTest extends ElementTest {
         + "</messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+    expectedException.expectMessage("The length of a text-field's initial value must be between 5 and 5");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
@@ -356,7 +356,7 @@ public class TextFieldTest extends ElementTest {
         + "</messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+    expectedException.expectMessage("The length of a text-field's initial value must be between 1 and 5");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
@@ -370,7 +370,7 @@ public class TextFieldTest extends ElementTest {
         + "</messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+    expectedException.expectMessage("The length of a text-field's initial value must be between 20 and 128");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
@@ -384,7 +384,7 @@ public class TextFieldTest extends ElementTest {
         + "</messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+    expectedException.expectMessage("The length of a text-field's initial value must be between 5 and 5");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
@@ -306,6 +306,90 @@ public class TextFieldTest extends ElementTest {
   }
 
   @Test
+  public void testTextFieldMessageMLWithDefaultValueBiggerThanMaxLength() throws Exception {
+    String input = "<messageML>"
+        + "<form id=\"" + FORM_ID_ATTR + "\">"
+        + "<text-field name=\"sample name\" maxlength=\"5\">Value here</text-field>"
+        + "</form>"
+        + "</messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testTextFieldMessageMLWithDefaultValueBiggerThanMinLength() throws Exception {
+    String input = "<messageML>"
+        + "<form id=\"" + FORM_ID_ATTR + "\">"
+        + "<text-field name=\"sample name\" minlength=\"20\">Value here</text-field>"
+        + "</form>"
+        + "</messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testTextFieldMessageMLWithMinAndMaxLengthWithTheSameValue() throws Exception {
+    String input = "<messageML>"
+        + "<form id=\"" + FORM_ID_ATTR + "\">"
+        + "<text-field name=\"sample name\" maxlength=\"5\" minlength=\"5\">Value here</text-field>"
+        + "</form>"
+        + "</messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testTextFieldPresentationMLWithDefaultValueBiggerThanMaxLength() throws Exception {
+    String input = "<messageML>"
+        + "<form id=\"" + FORM_ID_ATTR + "\">"
+        + "<input type=\"text\" name=\"sample name\" maxlength=\"5\" value=\"Value here\" />"
+        + "</form>"
+        + "</messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testTextFieldPresentationMLWithDefaultValueBiggerThanMinLength() throws Exception {
+    String input = "<messageML>"
+        + "<form id=\"" + FORM_ID_ATTR + "\">"
+        + "<input type=\"text\" name=\"sample name\" minlength=\"20\" value=\"Value here\" />"
+        + "</form>"
+        + "</messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testTextFieldPresentationMLWithMinAndMaxLengthWithTheSameValue() throws Exception {
+    String input = "<messageML>"
+        + "<form id=\"" + FORM_ID_ATTR + "\">"
+        + "<input type=\"text\" name=\"sample name\" maxlength=\"5\" minlength=\"5\" value=\"Value here\"/>"
+        + "</form>"
+        + "</messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The initial value of a text field must respect the minlength and maxlength set on its element");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testRequiredTextField() throws Exception {
     String name = "required-text-field";
     boolean required = true;


### PR DESCRIPTION
Adding validation to stop messages containing text-fields with an initial value bigger than the element's maxlength or smaller than its minlength

Fixes #145 