### PR TITLE
MML-203 - Changing Button class from 'primary-destructive' to 'primary' and 'secondary-destructive' to 'secondary'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,11 @@
             <version>${freemarker.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+        <dependency>
             <groupId>com.atlassian.commonmark</groupId>
             <artifactId>commonmark</artifactId>
             <version>${commonmark.version}</version>

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -1,6 +1,8 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
@@ -23,6 +25,8 @@ import java.util.Set;
  * @since 03/21/19
  */
 public class Button extends FormElement {
+  
+  Logger logger = LoggerFactory.getLogger(Button.class);
 
   public static final String MESSAGEML_TAG = "button";
   public static final String ACTION_TYPE = "action";
@@ -47,14 +51,10 @@ public class Button extends FormElement {
         break;
         // The button can a have tooltips but is not a tooltipable element because it dont generate the span with tooltip
       case CLASS_ATTR:
-        setAttribute(item.getNodeName(), getStringAttribute(item));
-        String clazz = getAttribute(CLASS_ATTR);
-        if("primary-destructive".equals(clazz)) {
-          setAttribute(item.getNodeName(), "primary");
+        if(getStringAttribute(item).contains("-destructive")) {
+          logger.info("Button class cannot be a destructive one, replacing it accordingly.");
         }
-        if("secondary-destructive".equals(clazz)) {
-          setAttribute(item.getNodeName(), "secondary");
-        }
+        setAttribute(item.getNodeName(), StringUtils.removeEnd(getStringAttribute(item), "-destructive"));
         break;
       case TooltipableElement.TITLE:
         if(format != FormatEnum.MESSAGEML){

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -43,10 +43,19 @@ public class Button extends FormElement {
     switch (item.getNodeName()) {
       case NAME_ATTR:
       case TYPE_ATTR:
-      case CLASS_ATTR:
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
         // The button can a have tooltips but is not a tooltipable element because it dont generate the span with tooltip
+      case CLASS_ATTR:
+        setAttribute(item.getNodeName(), getStringAttribute(item));
+        String clazz = getAttribute(CLASS_ATTR);
+        if("primary-destructive".equals(clazz)) {
+          setAttribute(item.getNodeName(), "primary");
+        }
+        if("secondary-destructive".equals(clazz)) {
+          setAttribute(item.getNodeName(), "secondary");
+        }
+        break;
       case TooltipableElement.TITLE:
         if(format != FormatEnum.MESSAGEML){
           throwInvalidInputException(item);
@@ -105,12 +114,6 @@ public class Button extends FormElement {
       throw new InvalidInputException("Attribute \"class\" must be \"primary\", \"secondary\", " +
               "\"tertiary\" or \"destructive\" (\"primary-destructive\" and \"secondary-destructive\" are deprecated)");
     }
-    if("primary-destructive".equals(clazz)) {
-      setAttribute(CLASS_ATTR, "primary");
-    }
-    if("secondary-destructive".equals(clazz)) {
-      setAttribute(CLASS_ATTR, "secondary");
-    }    
     if (type.equals(ACTION_TYPE) && StringUtils.isBlank(name)) {
       throw new InvalidInputException("Attribute \"name\" is required for action buttons");
     }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -105,6 +105,12 @@ public class Button extends FormElement {
       throw new InvalidInputException("Attribute \"class\" must be \"primary\", \"secondary\", " +
               "\"tertiary\" or \"destructive\" (\"primary-destructive\" and \"secondary-destructive\" are deprecated)");
     }
+    if("primary-destructive".equals(clazz)) {
+      setAttribute(CLASS_ATTR, "primary");
+    }
+    if("secondary-destructive".equals(clazz)) {
+      setAttribute(CLASS_ATTR, "secondary");
+    }    
     if (type.equals(ACTION_TYPE) && StringUtils.isBlank(name)) {
       throw new InvalidInputException("Attribute \"name\" is required for action buttons");
     }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
@@ -125,6 +125,12 @@ public class ButtonTest extends ElementTest {
       Element button = form.getChildren().get(0);
 
       assertEquals("Button class", Button.class, button.getClass());
+      if("primary-destructive".equals(clazz)) {
+        clazz = "primary";
+      }
+      if("secondary-destructive".equals(clazz)) {
+        clazz = "secondary";
+      }
       verifyButtonPresentation((Button) button, null, type, clazz, innerText);
     }
   }


### PR DESCRIPTION
If a user sends a Button with 'primary-destructive' or 'secondary-destructive' classes, we are converting it to 'primary' or 'secondary', respectively.
A info message will be shown in the Agent logs as
`2020-07-29 19:03:12,628 INFO  [org.symphonyoss.symphony.messageml.elements.Button] (https-jsse-nio-9443-exec-6) [Trace ID: OdZpMX] Button class cannot be a destructive one, replacing it accordingly.`
This is needed because the destructive values are deprecated and we don't accept them on the FE side anymore, so for now, we are just converting the values. In the future we will completely remove them and  prevent the user to send them.