### PR TITLE
MML-95 Add a No-Op Dataprovider

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Mention.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Mention.java
@@ -17,6 +17,7 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
 import org.commonmark.node.Node;
 import org.commonmark.node.Text;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
@@ -159,7 +160,7 @@ public class Mention extends Entity {
 
   @Override
   public String asText() {
-    return "@" + userPresentation.getPrettyName();
+    return StringUtils.isNotBlank(userPresentation.getPrettyName()) ? "@" + userPresentation.getPrettyName() : "";
   }
 
   @Override

--- a/src/main/java/org/symphonyoss/symphony/messageml/markdown/nodes/MentionNode.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/markdown/nodes/MentionNode.java
@@ -16,6 +16,7 @@
 
 package org.symphonyoss.symphony.messageml.markdown.nodes;
 
+import org.apache.commons.lang3.StringUtils;
 import org.commonmark.node.CustomNode;
 
 /**
@@ -61,7 +62,7 @@ public class MentionNode extends CustomNode {
   }
 
   public String getText() {
-    return PREFIX + prettyName;
+    return StringUtils.isNotBlank(prettyName) ? PREFIX + prettyName : "";
   }
 
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/util/NoOpDataProvider.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/util/NoOpDataProvider.java
@@ -1,0 +1,69 @@
+package org.symphonyoss.symphony.messageml.util;
+
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+
+import java.net.URI;
+
+/**
+ * A utility {@link IDataProvider} which populates {@link IUserPresentation} with the input (either user email or user ID)
+ * and always validates input URLs.
+ */
+public class NoOpDataProvider implements IDataProvider {
+  private class NoOpUserPresentation implements IUserPresentation {
+
+    private long id;
+    private final String screenName;
+    private final String prettyName;
+    private final String email;
+
+    public NoOpUserPresentation(String emailAddress) {
+      this.id = 0;
+      this.email = emailAddress;
+      this.screenName = emailAddress;
+      this.prettyName = emailAddress;
+    }
+
+    public NoOpUserPresentation(Long uid) {
+      this.id = uid;
+      this.screenName = String.valueOf(uid);
+      this.prettyName = String.valueOf(uid);
+      this.email = "";
+    }
+
+    @Override
+    public long getId() {
+      return this.id;
+    }
+
+    @Override
+    public String getScreenName() {
+      return this.screenName;
+    }
+
+    @Override
+    public String getPrettyName() {
+      return this.prettyName;
+    }
+
+    @Override
+    public String getEmail() {
+      return this.email;
+    }
+  }
+
+  @Override
+  public IUserPresentation getUserPresentation(String emailAddress) throws InvalidInputException {
+    return new NoOpUserPresentation(emailAddress);
+  }
+
+  @Override
+  public IUserPresentation getUserPresentation(Long uid) throws InvalidInputException {
+    return new NoOpUserPresentation(uid);
+  }
+
+  @Override
+  public void validateURI(URI uri) throws InvalidInputException, ProcessingException {
+    // no-op
+  }
+}

--- a/src/main/java/org/symphonyoss/symphony/messageml/util/NullDataProvider.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/util/NullDataProvider.java
@@ -1,0 +1,50 @@
+package org.symphonyoss.symphony.messageml.util;
+
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+
+import java.net.URI;
+
+/**
+ * A utility {@link IDataProvider} which populates {@link IUserPresentation} with empty strings and a user ID of 0 for every input
+ * and always validates input URLs.
+ */
+public class NullDataProvider implements IDataProvider {
+  private class NullUserPresentation implements IUserPresentation {
+
+    @Override
+    public long getId() {
+      return 0;
+    }
+
+    @Override
+    public String getScreenName() {
+      return "";
+    }
+
+    @Override
+    public String getPrettyName() {
+      return "";
+    }
+
+    @Override
+    public String getEmail() {
+      return "";
+    }
+  }
+
+  @Override
+  public IUserPresentation getUserPresentation(String emailAddress) throws InvalidInputException {
+    return new NullUserPresentation();
+  }
+
+  @Override
+  public IUserPresentation getUserPresentation(Long uid) throws InvalidInputException {
+    return new NullUserPresentation();
+  }
+
+  @Override
+  public void validateURI(URI uri) throws InvalidInputException, ProcessingException {
+    // no-op
+  }
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/LinkTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/LinkTest.java
@@ -1,11 +1,15 @@
 package org.symphonyoss.symphony.messageml.elements;
 
-import static org.junit.Assert.assertEquals;
-
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.util.IDataProvider;
+import org.symphonyoss.symphony.messageml.util.NoOpDataProvider;
+import org.symphonyoss.symphony.messageml.util.NullDataProvider;
+
+import static org.junit.Assert.assertEquals;
 
 public class LinkTest extends ElementTest {
 
@@ -86,5 +90,53 @@ public class LinkTest extends ElementTest {
     expectedException.expect(InvalidInputException.class);
     expectedException.expectMessage("The attribute \"href\" must contain an absolute URI");
     context.parseMessageML(invalidUri, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testLinkNullDataProvider() throws Exception {
+    String invalidUri = "<messageML><a href=\"invalid://hello.org\">Hello world!</a></messageML>";
+    IDataProvider nullProvider = new NullDataProvider();
+    MessageMLContext context = new MessageMLContext(nullProvider);
+
+    context.parseMessageML(invalidUri, null, MessageML.MESSAGEML_VERSION);
+
+    String presentationML = context.getPresentationML();
+    ObjectNode entityJson = context.getEntityJson();
+    String markdown = context.getMarkdown();
+    String text = context.getText();
+
+    String expectedPresentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\"><a href=\"invalid://hello.org\">Hello world!</a></div>";
+    String expectedJson = "{}";
+    String expectedMarkdown = "invalid://hello.org";
+    String expectedText = "Hello world!";
+
+    assertEquals("Generated PresentationML", expectedPresentationML, presentationML);
+    assertEquals("Generated EntityJSON", expectedJson, MAPPER.writeValueAsString(entityJson));
+    assertEquals("Generated Markdown", expectedMarkdown, markdown);
+    assertEquals("Generated text", expectedText, text);
+  }
+
+  @Test
+  public void testLinkNoOpDataProvider() throws Exception {
+    String invalidUri = "<messageML><a href=\"invalid://hello.org\">Hello world!</a></messageML>";
+    IDataProvider noOpProvider = new NoOpDataProvider();
+    MessageMLContext context = new MessageMLContext(noOpProvider);
+
+    context.parseMessageML(invalidUri, null, MessageML.MESSAGEML_VERSION);
+
+    String presentationML = context.getPresentationML();
+    ObjectNode entityJson = context.getEntityJson();
+    String markdown = context.getMarkdown();
+    String text = context.getText();
+
+    String expectedPresentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\"><a href=\"invalid://hello.org\">Hello world!</a></div>";
+    String expectedJson = "{}";
+    String expectedMarkdown = "invalid://hello.org";
+    String expectedText = "Hello world!";
+
+    assertEquals("Generated PresentationML", expectedPresentationML, presentationML);
+    assertEquals("Generated EntityJSON", expectedJson, MAPPER.writeValueAsString(entityJson));
+    assertEquals("Generated Markdown", expectedMarkdown, markdown);
+    assertEquals("Generated text", expectedText, text);
   }
 }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/MentionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/MentionTest.java
@@ -1,22 +1,18 @@
 package org.symphonyoss.symphony.messageml.elements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
-import org.symphonyoss.symphony.messageml.util.IDataProvider;
-import org.symphonyoss.symphony.messageml.util.TestDataProvider;
-import org.symphonyoss.symphony.messageml.util.UserPresentation;
+import org.symphonyoss.symphony.messageml.util.*;
 
 import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
 
 public class MentionTest extends ElementTest {
 
@@ -345,6 +341,114 @@ public class MentionTest extends ElementTest {
     context.parseMessageML(invalidElement, null, MessageML.MESSAGEML_VERSION);
   }
 
+  @Test
+  public void testNullDataProviderMentionByEmail() throws Exception {
+    String input = "<messageML>Hello <mention email=\"bot.user1@localhost.com\"/>!</messageML>";
+
+    IDataProvider nullProvider = new NullDataProvider();
+    MessageMLContext context = new MessageMLContext(nullProvider);
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    String presentationML = context.getPresentationML();
+    ObjectNode entityJson = context.getEntityJson();
+    String markdown = context.getMarkdown();
+    String text = context.getText();
+
+    String expectedPresentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
+        "Hello <span class=\"entity\" data-entity-id=\"mention1\"></span>!" +
+        "</div>";
+    String expectedJson = "{\"mention1\":{\"type\":\"com.symphony.user.mention\",\"version\":\"1.0\",\"id\":[{\"type\":\"com.symphony.user.userId\",\"value\":\"0\"}]}}";
+    String expectedMarkdown = "Hello !";
+    String expectedText = "Hello !";
+
+    assertEquals("Generated PresentationML", expectedPresentationML, presentationML);
+    assertEquals("Generated EntityJSON", expectedJson, MAPPER.writeValueAsString(entityJson));
+    assertEquals("Generated Markdown", expectedMarkdown, markdown);
+    assertEquals("Generated text", expectedText, text);
+  }
+
+  @Test
+  public void testNullDataProviderMentionByUid() throws Exception {
+    String input = "<messageML>Hello <mention uid=\"1000\"/>!</messageML>";
+
+    IDataProvider nullProvider = new NullDataProvider();
+    MessageMLContext context = new MessageMLContext(nullProvider);
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    String presentationML = context.getPresentationML();
+    ObjectNode entityJson = context.getEntityJson();
+    String markdown = context.getMarkdown();
+    String text = context.getText();
+
+    String expectedPresentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
+        "Hello <span class=\"entity\" data-entity-id=\"mention1\"></span>!" +
+        "</div>";
+    String expectedJson = "{\"mention1\":{\"type\":\"com.symphony.user.mention\",\"version\":\"1.0\",\"id\":[{\"type\":\"com.symphony.user.userId\",\"value\":\"1000\"}]}}";
+    String expectedMarkdown = "Hello !";
+    String expectedText = "Hello !";
+
+    assertEquals("Generated PresentationML", expectedPresentationML, presentationML);
+    assertEquals("Generated EntityJSON", expectedJson, MAPPER.writeValueAsString(entityJson));
+    assertEquals("Generated Markdown", expectedMarkdown, markdown);
+    assertEquals("Generated text", expectedText, text);
+  }
+
+  @Test
+  public void testNoOpDataProviderMentionByEmail() throws Exception {
+    String input = "<messageML>Hello <mention email=\"bot.user1@localhost.com\"/>!</messageML>";
+
+    IDataProvider noOpProvider = new NoOpDataProvider();
+    MessageMLContext context = new MessageMLContext(noOpProvider);
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    String presentationML = context.getPresentationML();
+    ObjectNode entityJson = context.getEntityJson();
+    String markdown = context.getMarkdown();
+    String text = context.getText();
+
+    String expectedPresentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
+        "Hello <span class=\"entity\" data-entity-id=\"mention1\">@bot.user1@localhost.com</span>!" +
+        "</div>";
+    String expectedJson = "{\"mention1\":{\"type\":\"com.symphony.user.mention\",\"version\":\"1.0\",\"id\":[{\"type\":\"com.symphony.user.userId\",\"value\":\"0\"}]}}";
+    String expectedMarkdown = "Hello @bot.user1@localhost.com!";
+    String expectedText = "Hello @bot.user1@localhost.com!";
+
+    assertEquals("Generated PresentationML", expectedPresentationML, presentationML);
+    assertEquals("Generated EntityJSON", expectedJson, MAPPER.writeValueAsString(entityJson));
+    assertEquals("Generated Markdown", expectedMarkdown, markdown);
+    assertEquals("Generated text", expectedText, text);
+  }
+
+  @Test
+  public void testNoOpDataProviderMentionByUid() throws Exception {
+    String input = "<messageML>Hello <mention uid=\"1000\"/>!</messageML>";
+
+    IDataProvider noOpProvider = new NoOpDataProvider();
+    MessageMLContext context = new MessageMLContext(noOpProvider);
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    String presentationML = context.getPresentationML();
+    ObjectNode entityJson = context.getEntityJson();
+    String markdown = context.getMarkdown();
+    String text = context.getText();
+
+    String expectedPresentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
+        "Hello <span class=\"entity\" data-entity-id=\"mention1\">@1000</span>!" +
+        "</div>";
+    String expectedJson = "{\"mention1\":{\"type\":\"com.symphony.user.mention\",\"version\":\"1.0\",\"id\":[{\"type\":\"com.symphony.user.userId\",\"value\":\"1000\"}]}}";
+    String expectedMarkdown = "Hello @1000!";
+    String expectedText = "Hello @1000!";
+
+    assertEquals("Generated PresentationML", expectedPresentationML, presentationML);
+    assertEquals("Generated EntityJSON", expectedJson, MAPPER.writeValueAsString(entityJson));
+    assertEquals("Generated Markdown", expectedMarkdown, markdown);
+    assertEquals("Generated text", expectedText, text);
+  }
+
   private void verifyMention(Element messageML, UserPresentation user, String expectedPresentationML, String expectedJson)
       throws Exception {
     assertEquals("Element children", 3, messageML.getChildren().size());
@@ -371,4 +475,5 @@ public class MentionTest extends ElementTest {
     assertEquals("Entity end index", 17, entity.get(0).get("indexEnd").intValue());
     assertEquals("Entity type", "USER_FOLLOW", entity.get(0).get("type").textValue());
   }
+
 }


### PR DESCRIPTION
1. Adds a `NullDataProvider` which resolves all `<mention/>` inputs to empty strings and always validates URLs positively.

Usage:

```
String input = "<messageML>Hello <mention email=\"bot.user1@localhost.com\"/>!</messageML>";

IDataProvider nullProvider = new NullDataProvider();
MessageMLContext context = new MessageMLContext(nullProvider);

context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);

// context.getPresentationML();
String expectedPresentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
        "Hello <span class=\"entity\" data-entity-id=\"mention1\"></span>!" +
        "</div>";
// context.getEntityJson();
String expectedJson = "{\"mention1\":{\"type\":\"com.symphony.user.mention\",\"version\":\"1.0\",\"id\":[{\"type\":\"com.symphony.user.userId\",\"value\":\"0\"}]}}";
// context.getMarkdown();
String expectedMarkdown = "Hello !";
// context.getText();
String expectedText = "Hello !";
```

2. Adds a `NoOpDataProvider` which resolves all `<mention/>` inputs to the input data and always validates URLs positively.

Usage:

```
String input = "<messageML>Hello <mention uid=\"1000\"/>!</messageML>";

IDataProvider noOpProvider = new NoOpDataProvider();
MessageMLContext context = new MessageMLContext(noOpProvider);

context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);

// context.getPresentationML();
String expectedPresentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
        "Hello <span class=\"entity\" data-entity-id=\"mention1\">@1000</span>!" +
        "</div>";
// context.getEntityJson();
String expectedJson = "{\"mention1\":{\"type\":\"com.symphony.user.mention\",\"version\":\"1.0\",\"id\":[{\"type\":\"com.symphony.user.userId\",\"value\":\"1000\"}]}}";
// context.getMarkdown();
String expectedMarkdown = "Hello @1000!";
// context.getText();
String expectedText = "Hello @1000!";
```