### PR TITLE
MML-227 Datepicker: Restrict format values

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
@@ -45,7 +45,7 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
 
   private final ObjectMapper mapper;
 
-  private static final String dateFormatAllowed = "^[0-9Mdy\\/. -]+$";
+  private static final String DATE_FORMAT_ALLOWED = "^[0-9Mdy\\/. -:]+$";
 
   public DatePicker(Element parent, FormatEnum format) {
     super(parent, MESSAGEML_TAG, format);
@@ -113,9 +113,9 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
     if (getAttribute(FORMAT_ATTR) != null) {
       assertAttributeMaxLength(FORMAT_ATTR, DEFAULT_MAX_LENGTH);
       String format = getAttribute(FORMAT_ATTR);
-      if(!format.matches(dateFormatAllowed)){
+      if(!format.matches(DATE_FORMAT_ALLOWED)){
         throw new InvalidInputException(
-            String.format("Attribute \"%s\" contains an unsupported date format, only 'M', 'd' and 'y' are supported with a space or '.','-','/' as separator", FORMAT_ATTR)
+            String.format("Attribute \"%s\" contains an unsupported date format, only 'M', 'd' and 'y' are supported with a space or '.','-','/', ':' as separator", FORMAT_ATTR)
         );
       }
       try {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
@@ -2,7 +2,6 @@ package org.symphonyoss.symphony.messageml.elements;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.Range;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
@@ -44,9 +43,9 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
   private static final String HIGHLIGHTED_DATE_PRESENTATION_ATTR = "data-highlighted-date";
   private static final String FORMAT_PRESENTATION_ATTR = "data-format";
 
-  private static final Range<Integer> ALLOWED_DAYS = Range.between(0, 6);
-
   private final ObjectMapper mapper;
+
+  private static final String dateFormatAllowed = "^[0-9Mdy\\/. -]+$";
 
   public DatePicker(Element parent, FormatEnum format) {
     super(parent, MESSAGEML_TAG, format);
@@ -113,8 +112,14 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
 
     if (getAttribute(FORMAT_ATTR) != null) {
       assertAttributeMaxLength(FORMAT_ATTR, DEFAULT_MAX_LENGTH);
+      String format = getAttribute(FORMAT_ATTR);
+      if(!format.matches(dateFormatAllowed)){
+        throw new InvalidInputException(
+            String.format("Attribute \"%s\" contains an unsupported date format, only 'M', 'd' and 'y' are supported with a space or '.','-','/' as separator", FORMAT_ATTR)
+        );
+      }
       try {
-        DateTimeFormatter.ofPattern(getAttribute(FORMAT_ATTR));
+        DateTimeFormatter.ofPattern(getAttribute(FORMAT_ATTR)).toFormat();
       } catch (IllegalArgumentException i) {
         throw new InvalidInputException(
             String.format("Attribute \"%s\" contains an invalid date format", FORMAT_ATTR));

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
@@ -115,7 +115,7 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
       String format = getAttribute(FORMAT_ATTR);
       if(!format.matches(DATE_FORMAT_ALLOWED)){
         throw new InvalidInputException(
-            String.format("Attribute \"%s\" contains an unsupported date format, only 'M', 'd' and 'y' are supported with a space or '.','-','/', ':' as separator", FORMAT_ATTR)
+            String.format("Attribute \"%s\" contains an unsupported date format, only 'M', 'd' and 'y' are supported with a space or '.','-','/',':' as separator", FORMAT_ATTR)
         );
       }
       try {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
@@ -119,7 +119,7 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
         );
       }
       try {
-        DateTimeFormatter.ofPattern(getAttribute(FORMAT_ATTR)).toFormat();
+        DateTimeFormatter.ofPattern(getAttribute(FORMAT_ATTR));
       } catch (IllegalArgumentException i) {
         throw new InvalidInputException(
             String.format("Attribute \"%s\" contains an invalid date format", FORMAT_ATTR));

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
@@ -270,6 +270,86 @@ public class DatePickerTest extends ElementTest {
   }
 
   @Test
+  public void sendSeparator1DateFormat() throws Exception {
+    String input = "<messageML><form id=\"" + formId + "\">"
+        + "<date-picker \n"
+        + "      name=\"date-travel\"\n"
+        + "      value=\"2020-09-15\"\n"
+        + "      placeholder=\"Please pick a date\"\n"
+        + "      min=\"2020-09-01\"\n"
+        + "      max=\"2020-09-29\"\n"
+        + "      disabled-date='[{\"day\": \"2020-09-23\"}, {\"from\": \"2020-09-18\", \"to\": \"2020-09-20\"}, "
+        + "{\"daysOfWeek\": [0,1]}]'"
+        + "      highlighted-date='[{\"day\": \"2020-09-24\"}, {\"from\": \"2020-09-26\", \"to\": \"2020-09-28\"}, "
+        + "{\"day\": \"2020-09-03\"}, {\"daysOfWeek\": [4,6]}]'"
+        + "      required=\"true\"\n"
+        + "      format=\"yyyy/MM/dd\"\n"
+        + "    />"
+        + ACTION_BTN_ELEMENT + "</form></messageML>";
+    context.parseMessageML(input,null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void sendSeparator2DateFormat() throws Exception {
+    String input = "<messageML><form id=\"" + formId + "\">"
+        + "<date-picker \n"
+        + "      name=\"date-travel\"\n"
+        + "      value=\"2020-09-15\"\n"
+        + "      placeholder=\"Please pick a date\"\n"
+        + "      min=\"2020-09-01\"\n"
+        + "      max=\"2020-09-29\"\n"
+        + "      disabled-date='[{\"day\": \"2020-09-23\"}, {\"from\": \"2020-09-18\", \"to\": \"2020-09-20\"}, "
+        + "{\"daysOfWeek\": [0,1]}]'"
+        + "      highlighted-date='[{\"day\": \"2020-09-24\"}, {\"from\": \"2020-09-26\", \"to\": \"2020-09-28\"}, "
+        + "{\"day\": \"2020-09-03\"}, {\"daysOfWeek\": [4,6]}]'"
+        + "      required=\"true\"\n"
+        + "      format=\"yyyy:MM:dd\"\n"
+        + "    />"
+        + ACTION_BTN_ELEMENT + "</form></messageML>";
+    context.parseMessageML(input,null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void sendSeparator3DateFormat() throws Exception {
+    String input = "<messageML><form id=\"" + formId + "\">"
+        + "<date-picker \n"
+        + "      name=\"date-travel\"\n"
+        + "      value=\"2020-09-15\"\n"
+        + "      placeholder=\"Please pick a date\"\n"
+        + "      min=\"2020-09-01\"\n"
+        + "      max=\"2020-09-29\"\n"
+        + "      disabled-date='[{\"day\": \"2020-09-23\"}, {\"from\": \"2020-09-18\", \"to\": \"2020-09-20\"}, "
+        + "{\"daysOfWeek\": [0,1]}]'"
+        + "      highlighted-date='[{\"day\": \"2020-09-24\"}, {\"from\": \"2020-09-26\", \"to\": \"2020-09-28\"}, "
+        + "{\"day\": \"2020-09-03\"}, {\"daysOfWeek\": [4,6]}]'"
+        + "      required=\"true\"\n"
+        + "      format=\"yyyy.MM.dd\"\n"
+        + "    />"
+        + ACTION_BTN_ELEMENT + "</form></messageML>";
+    context.parseMessageML(input,null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void sendSeparator4DateFormat() throws Exception {
+    String input = "<messageML><form id=\"" + formId + "\">"
+        + "<date-picker \n"
+        + "      name=\"date-travel\"\n"
+        + "      value=\"2020-09-15\"\n"
+        + "      placeholder=\"Please pick a date\"\n"
+        + "      min=\"2020-09-01\"\n"
+        + "      max=\"2020-09-29\"\n"
+        + "      disabled-date='[{\"day\": \"2020-09-23\"}, {\"from\": \"2020-09-18\", \"to\": \"2020-09-20\"}, "
+        + "{\"daysOfWeek\": [0,1]}]'"
+        + "      highlighted-date='[{\"day\": \"2020-09-24\"}, {\"from\": \"2020-09-26\", \"to\": \"2020-09-28\"}, "
+        + "{\"day\": \"2020-09-03\"}, {\"daysOfWeek\": [4,6]}]'"
+        + "      required=\"true\"\n"
+        + "      format=\"yyyy MM dd\"\n"
+        + "    />"
+        + ACTION_BTN_ELEMENT + "</form></messageML>";
+    context.parseMessageML(input,null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testEmptyMarkdown() throws Exception {
     String input = "<messageML><form id=\"" + formId + "\">"
         + "<date-picker name=\"date-travel\"/>"

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
@@ -265,7 +265,7 @@ public class DatePickerTest extends ElementTest {
 
     expectedException.expect(InvalidInputException.class);
     expectedException.expectMessage("Attribute \"format\" contains an unsupported date format, "
-        + "only 'M', 'd' and 'y' are supported with a space or '.','-','/' as separator");
+        + "only 'M', 'd' and 'y' are supported with a space or '.','-','/',':' as separator");
     context.parseMessageML(input,null, MessageML.MESSAGEML_VERSION);
   }
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
@@ -246,6 +246,30 @@ public class DatePickerTest extends ElementTest {
   }
 
   @Test
+  public void sendUnsupportedDateFormat() throws Exception {
+    String input = "<messageML><form id=\"" + formId + "\">"
+        + "<date-picker \n"
+        + "      name=\"date-travel\"\n"
+        + "      value=\"2020-09-15\"\n"
+        + "      placeholder=\"Please pick a date\"\n"
+        + "      min=\"2020-09-01\"\n"
+        + "      max=\"2020-09-29\"\n"
+        + "      disabled-date='[{\"day\": \"2020-09-23\"}, {\"from\": \"2020-09-18\", \"to\": \"2020-09-20\"}, "
+        + "{\"daysOfWeek\": [0,1]}]'"
+        + "      highlighted-date='[{\"day\": \"2020-09-24\"}, {\"from\": \"2020-09-26\", \"to\": \"2020-09-28\"}, "
+        + "{\"day\": \"2020-09-03\"}, {\"daysOfWeek\": [4,6]}]'"
+        + "      required=\"true\"\n"
+        + "      format=\"yyyy-MM-dd HH:mm:ss\"\n"
+        + "    />"
+        + ACTION_BTN_ELEMENT + "</form></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"format\" contains an unsupported date format, "
+        + "only 'M', 'd' and 'y' are supported with a space or '.','-','/' as separator");
+    context.parseMessageML(input,null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testEmptyMarkdown() throws Exception {
     String input = "<messageML><form id=\"" + formId + "\">"
         + "<date-picker name=\"date-travel\"/>"


### PR DESCRIPTION
Restrict possible date format placeholders to 'M', 'd', and 'y'. Right now it is possible to add seconds, minutes, etc, which can create issues and confusion.