### PR TITLE
MML-229 using UTF-8 encoding while parsing MessageML

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -79,6 +79,7 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -311,7 +312,7 @@ public class MessageMLParser {
       dBuilder.setEntityResolver(new NoOpEntityResolver());
 
       StringReader sr = new StringReader(messageML);
-      ReaderInputStream ris = new ReaderInputStream(sr);
+      ReaderInputStream ris = new ReaderInputStream(sr, StandardCharsets.UTF_8);
 
       Document doc = dBuilder.parse(ris);
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
@@ -117,6 +117,18 @@ public class MessageMLContextTest {
   }
 
   @Test
+  public void testParseMessageMLUmlautsCharacters()
+          throws InvalidInputException, IOException, ProcessingException {
+    final String message = "<messageML>Leseübungen</messageML>";
+
+    context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
+    String presentationML = context.getPresentationML();
+    String expectedResult = "<div data-format=\"PresentationML\" data-version=\"2.0\">Leseübungen</div>";
+
+    assertEquals(expectedResult, presentationML);
+  }
+
+  @Test
   public void testParseMessageMLTextFieldWithSplittables()
       throws InvalidInputException, IOException, ProcessingException {
     final String message = "<messageML>\n"


### PR DESCRIPTION
Currently in the MessageMLParser.java is not specifying the type of encoding that should be used while parsing a messageML, the goal of this issue is to change this behaviour to always use UTF-8 encoding.
Related issue: https://github.com/symphonyoss/messageml-utils/issues/229