### PR TITLE
PLAT-9093: PR based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,12 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      release-version:
-        description: 'Release version'
-        required: true
-      dev-version:
-        description: 'Next development version'
-        required: true
+  release:
+    types: [published]
 
 jobs:
   build:
-    name: "Release version ${{ github.event.inputs.release-version }}"
+    name: "Release version ${GITHUB_REF##*/}"
 
     runs-on: ubuntu-latest
 
@@ -34,22 +28,9 @@ jobs:
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-      - name: Configure Git user
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
       - name: Release and deploy with Maven
-        run: mvn -B --file pom.xml release:prepare release:perform -Prelease -DdevelopmentVersion=${{ github.event.inputs.dev-version }} -DreleaseVersion=${{ github.event.inputs.release-version }}
+        run: mvn -B --file pom.xml deploy
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
-      - name: Create Github release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: messageml-${{ github.event.inputs.release-version }}
-          release_name: MessageML ${{ github.event.inputs.release-version }}
-          draft: true

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.symphonyoss.symphony</groupId>
     <artifactId>messageml</artifactId>
-    <version>0.9.68-SNAPSHOT</version>
+    <version>0.9.67-SNAPSHOT</version>
     <name>MessageML Utils</name>
     <url>https://github.com/symphonyoss/messageml-utils</url>
     <description>A set of utilities for parsing, processing and rendering of MessageML messages</description>


### PR DESCRIPTION
To preserve Git branch protection rules, the release workflow has been
changed to locally bump the versions, open a PR with the changes, get it
merged and from there create a GH release.

Then the workflow is triggered automatically and deploy the release on
Maven Central.