### PR TITLE
PLAT-10552 : bump Freemarker and Jackson-databind versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,10 +113,10 @@
         <json.schema.validator.version>2.2.10</json.schema.validator.version>
         <guava.version>28.0-jre</guava.version>
         <jackson.version>2.10.1</jackson.version>
-        <jackson.databind.version>2.10.1</jackson.databind.version>
+        <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang3.version>3.4</commons.lang3.version>
-        <freemarker.version>2.3.28</freemarker.version>
+        <freemarker.version>2.3.30</freemarker.version>
         <commonmark.version>0.15.1</commonmark.version>
         <junit.version>4.13.1</junit.version>
         <mockito.version>1.9.5</mockito.version>


### PR DESCRIPTION
This PR is related to [PLAT-10552](https://perzoinc.atlassian.net/browse/PLAT-10552)
Snyk scan has reported a security issue with high severity in Freemarker module. Running the script test command locally, another issue related to Jackson-databind was found.

We fixed this by bumping dependency version from 2.3.28 to 2.3.30 and Jackson-databind from 2.10.1 to 2.10.5.1