### PR TITLE
MML-258 Prepare messageml-utils to provide BiContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
         <mockito.version>1.9.5</mockito.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven-model.version>3.3.9</maven-model.version>
         <jsonassert.version>1.5.0</jsonassert.version>
     </properties>
 
@@ -292,6 +293,11 @@
             <artifactId>jsonassert</artifactId>
             <version>${jsonassert.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${maven-model.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <mockito.version>1.9.5</mockito.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven-model.version>3.3.9</maven-model.version>
+        <maven.jar.version>3.1.2</maven.jar.version>
         <jsonassert.version>1.5.0</jsonassert.version>
     </properties>
 
@@ -152,6 +152,22 @@
             </properties>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>${maven.jar.version}</version>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <Implementation-Title>${project.name}</Implementation-Title>
+                                    <Implementation-Version>${project.version}</Implementation-Version>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </plugin>
                     <!-- Configure Jacoco to report coverage in Sonar -->
                     <plugin>
                         <groupId>org.jacoco</groupId>
@@ -293,11 +309,6 @@
             <artifactId>jsonassert</artifactId>
             <version>${jsonassert.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>${maven-model.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLContext.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLContext.java
@@ -19,6 +19,7 @@ package org.symphonyoss.symphony.messageml;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
@@ -48,6 +49,7 @@ public class MessageMLContext {
   private final MessageMLParser messageMLParser;
   private final MarkdownParser markdownParser;
   private final ShortID shortID;
+
   private MarkdownRenderer markdownRenderer;
   private MessageML messageML;
   private ObjectNode entityJson;
@@ -218,6 +220,20 @@ public class MessageMLContext {
 
   public String generateShortId(){
     return shortID.generate();
+  }
+
+  /**
+   * This method returns a {@link BiContext} which contains all BI data collected while parsing the MessageML.
+   * Make sure you first call {@link #parseMessageML} in order to collect the items first.
+   *
+   */
+  public BiContext getBiContext() {
+    BiContext biContext = messageMLParser.getBiContext();
+    if (biContext.getItems().isEmpty()) {
+      throw new IllegalStateException("The message hasn't been parsed yet so no BI has been collected. "
+              + "Please call MessageMLContext.parseMessageML() first.");
+    }
+    return biContext;
   }
 
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLContext.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLContext.java
@@ -228,12 +228,7 @@ public class MessageMLContext {
    *
    */
   public BiContext getBiContext() {
-    BiContext biContext = messageMLParser.getBiContext();
-    if (biContext.getItems().isEmpty()) {
-      throw new IllegalStateException("The message hasn't been parsed yet so no BI has been collected. "
-              + "Please call MessageMLContext.parseMessageML() first.");
-    }
-    return biContext;
+    return messageMLParser.getBiContext();
   }
 
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -15,6 +15,7 @@ import freemarker.template.TemplateExceptionHandler;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.elements.Bold;
 import org.symphonyoss.symphony.messageml.elements.BulletList;
 import org.symphonyoss.symphony.messageml.elements.Button;
@@ -111,6 +112,7 @@ public class MessageMLParser {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final Configuration FREEMARKER = new Configuration(Configuration.getVersion());
   private final IDataProvider dataProvider;
+  private final BiContext biContext;
 
   private FormatEnum messageFormat;
   private MessageML messageML;
@@ -131,6 +133,7 @@ public class MessageMLParser {
 
   MessageMLParser(IDataProvider dataProvider) {
     this.dataProvider = dataProvider;
+    this.biContext = new BiContext();
   }
 
   /**
@@ -141,10 +144,8 @@ public class MessageMLParser {
    * @param version string containing the version of the message format
    * @throws InvalidInputException thrown on invalid MessageMLV2 input
    * @throws ProcessingException thrown on errors generating the document tree
-   * @throws IOException thrown on invalid EntityJSON input
    */
-  MessageML parse(String message, String entityJson, String version) throws InvalidInputException, ProcessingException,
-      IOException {
+  MessageML parse(String message, String entityJson, String version) throws InvalidInputException, ProcessingException {
     this.index = 0;
     this.elementIds = new HashSet<>();
     this.splittableComponents = new HashMap<>();
@@ -174,14 +175,10 @@ public class MessageMLParser {
     }
 
     this.messageML = parseMessageML(expandedMessage, version);
+    this.entityJson = this.messageML.asEntityJson(this.entityJson);
 
-    if (this.messageML != null) {
-      this.entityJson = this.messageML.asEntityJson(this.entityJson);
+    return this.messageML;
 
-      return this.messageML;
-    }
-
-    throw new ProcessingException("Internal error. Generated null MessageML from valid input");
   }
 
   /**
@@ -733,6 +730,10 @@ public class MessageMLParser {
 
   public FormatEnum getMessageFormat() {
     return messageFormat;
+  }
+
+  public BiContext getBiContext() {
+    return biContext;
   }
 
   /**

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiContext.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiContext.java
@@ -1,0 +1,101 @@
+package org.symphonyoss.symphony.messageml.bi;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileReader;
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Contains all required BI data for MessageML instrumentation. It's composed by a list of {@link BiItem}, one per element
+ * found inside the message along with the current messageML-utils version.
+ */
+public class BiContext {
+
+  private final String libraryVersion;
+
+  private final List<BiItem> items;
+
+  private static final Logger logger = LoggerFactory.getLogger(BiContext.class);
+
+  public BiContext() {
+    this.libraryVersion = extractVersion();
+    this.items = new ArrayList<>();
+  }
+
+  /**
+   * Returns the messageML library version in use. Format is the following: "MessageML #version"
+   */
+  public String getLibraryVersion() {
+    return libraryVersion;
+  }
+
+  public List<BiItem> getItems() {
+    return items;
+  }
+
+  /**
+   * Adds a specific item to the context. No check if an item with same name already exists, the item will be added in
+   * any case.
+   * @param item to be added
+   */
+  public void addItem(BiItem item) {
+    items.add(item);
+  }
+
+  /**
+   * Used for simple messageML elements (like Paragraphs, Links, Headers) where we only want to keep the count of attributes found.
+   * It checks if the context already has an item for the element and if that's the case it will increase the count of
+   * the specific attribute. If context does not have the item it will create a new one with default values.
+   * @param itemName name of the element to be checked
+   * @param attributeName name of the attribute to be increased
+   */
+  public void updateItemInContext(String itemName, String attributeName) {
+    Map<String, String> attributes =  new HashMap<>();
+    Optional<BiItem> optionalBiItem = getItemWithName(itemName);
+    if(optionalBiItem.isPresent()){
+      BiItem item = optionalBiItem.get();
+      items.remove(item);
+      item.increaseAttributeCount(attributeName);
+      addItem(item);
+    } else {
+      attributes.put(attributeName, String.valueOf(1));
+      addItem(new BiItem(itemName, attributes));
+    }
+  }
+
+  private Optional<BiItem> getItemWithName(String itemName){
+    for(BiItem item: getItems()){
+      if(item.getName().equals(itemName)){
+        return Optional.of(item);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private String extractVersion(){
+    StringBuilder version = new StringBuilder("MessageML ");
+    MavenXpp3Reader reader = new MavenXpp3Reader();
+    Model model;
+    try {
+      model = reader.read(new FileReader("pom.xml"));
+    } catch (IOException | XmlPullParserException e) {
+      logger.warn("Failed to extract the messageML library version.");
+      return StringUtils.EMPTY;
+    }
+    if(model != null){
+      version.append(model.getVersion());
+    }
+    return version.toString();
+  }
+}

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiContext.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiContext.java
@@ -1,19 +1,10 @@
 package org.symphonyoss.symphony.messageml.bi;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.model.Model;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileReader;
-import java.io.IOException;
-
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -21,12 +12,10 @@ import java.util.Optional;
  * found inside the message along with the current messageML-utils version.
  */
 public class BiContext {
+  private static final Logger logger = LoggerFactory.getLogger(BiContext.class);
 
   private final String libraryVersion;
-
   private final List<BiItem> items;
-
-  private static final Logger logger = LoggerFactory.getLogger(BiContext.class);
 
   public BiContext() {
     this.libraryVersion = extractVersion();
@@ -47,6 +36,7 @@ public class BiContext {
   /**
    * Adds a specific item to the context. No check if an item with same name already exists, the item will be added in
    * any case.
+   *
    * @param item to be added
    */
   public void addItem(BiItem item) {
@@ -57,42 +47,29 @@ public class BiContext {
    * Used for simple messageML elements (like Paragraphs, Links, Headers) where we only want to keep the count of attributes found.
    * It checks if the context already has an item for the element and if that's the case it will increase the count of
    * the specific attribute. If context does not have the item it will create a new one with default values.
-   * @param itemName name of the element to be checked
+   *
+   * @param itemName      name of the element to be checked
    * @param attributeName name of the attribute to be increased
    */
   public void updateItem(String itemName, String attributeName) {
     Optional<BiItem> optionalBiItem = getItemWithName(itemName);
-    if(optionalBiItem.isPresent()){
+    if (optionalBiItem.isPresent()) {
       optionalBiItem.get().increaseAttributeCount(attributeName);
     } else {
-      Map<String, String> attributes =  new HashMap<>();
-      attributes.put(attributeName, String.valueOf(1));
-      addItem(new BiItem(itemName, attributes));
+      addItem(new BiItem(itemName, attributeName));
     }
   }
 
-  private Optional<BiItem> getItemWithName(String itemName){
-    for(BiItem item: getItems()){
-      if(item.getName().equals(itemName)){
-        return Optional.of(item);
-      }
-    }
-    return Optional.empty();
+  private Optional<BiItem> getItemWithName(String itemName) {
+    return getItems().stream().filter(item -> item.getName().equals(itemName)).findFirst();
   }
 
-  private String extractVersion(){
-    StringBuilder version = new StringBuilder("MessageML ");
-    MavenXpp3Reader reader = new MavenXpp3Reader();
-    Model model;
-    try {
-      model = reader.read(new FileReader("pom.xml"));
-    } catch (IOException | XmlPullParserException e) {
+  private static String extractVersion() {
+    String version = BiContext.class.getPackage().getImplementationVersion();
+    if (version == null || version.isEmpty()) {
       logger.warn("Failed to extract the messageML library version.");
-      return StringUtils.EMPTY;
+      version = "Unknown";
     }
-    if(model != null){
-      version.append(model.getVersion());
-    }
-    return version.toString();
+    return "MessageML " + version;
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiContext.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiContext.java
@@ -60,15 +60,12 @@ public class BiContext {
    * @param itemName name of the element to be checked
    * @param attributeName name of the attribute to be increased
    */
-  public void updateItemInContext(String itemName, String attributeName) {
-    Map<String, String> attributes =  new HashMap<>();
+  public void updateItem(String itemName, String attributeName) {
     Optional<BiItem> optionalBiItem = getItemWithName(itemName);
     if(optionalBiItem.isPresent()){
-      BiItem item = optionalBiItem.get();
-      items.remove(item);
-      item.increaseAttributeCount(attributeName);
-      addItem(item);
+      optionalBiItem.get().increaseAttributeCount(attributeName);
     } else {
+      Map<String, String> attributes =  new HashMap<>();
       attributes.put(attributeName, String.valueOf(1));
       addItem(new BiItem(itemName, attributes));
     }

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
@@ -1,0 +1,62 @@
+package org.symphonyoss.symphony.messageml.bi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * A BiItem can be any MessageML element such as <text-field>, <emoji>, <h1>, etc.
+ */
+public class BiItem {
+
+  private static final Logger logger = LoggerFactory.getLogger(BiContext.class);
+
+  private final String name;
+
+  private Map<String, String> attributes;
+
+  public BiItem(String name, Map<String, String> attributes) {
+    this.name = name;
+    this.attributes = attributes;
+  }
+
+  /**
+   * Returns the name of the MessageML element
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Returns a map containing all the attributes for a specific MessageML element.
+   * The map is composed by a key/value pair where the key is the name of the attribute and the value is either the number
+   * of occurrences for generic attributes of the value or the attribute it self (e.g Button type can be either "action" or "reset").
+   * If a specific attribute is not present the respective value will be set to an empty string.
+   */
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+  /**
+   * If the attribute is found inside the map the corresponding value will be increased, otherwise the attribute will be
+   * put in the map with value 1.
+   * If the value found is not an integer, then no update will be performed.
+   * @param attributeName name of the attribute to be increased in value
+   */
+  protected void increaseAttributeCount(String attributeName){
+    int value = 1;
+    if(attributes.containsKey(attributeName)){
+      String valueFound = attributes.get(attributeName);
+    try{
+        value = Integer.parseInt(valueFound) + 1;
+      } catch (NumberFormatException e){
+        logger.warn("Attribute {} for element {} does not contain an integer value. The count will not be increased.",
+                attributeName, getName());
+        return;
+      }
+    }
+    attributes.put(attributeName, String.valueOf(value));
+  }
+
+}

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
@@ -3,6 +3,7 @@ package org.symphonyoss.symphony.messageml.bi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -13,12 +14,25 @@ public class BiItem {
   private static final Logger logger = LoggerFactory.getLogger(BiContext.class);
 
   private final String name;
-
   private final Map<String, String> attributes;
 
   public BiItem(String name, Map<String, String> attributes) {
     this.name = name;
     this.attributes = attributes;
+  }
+
+  /**
+   * Constructor which takes an item name and an attribute name and initialize a map of attribute
+   * setting the attribute value by default to 1.
+   * @param name ot the item to be created
+   * @param attribute name of the attribute to be included in the attributes map
+   */
+  public BiItem(String name, String attribute) {
+    this.name = name;
+    Map<String, String> attributes =  new HashMap<>();
+    attributes.put(attribute, String.valueOf(1));
+    this.attributes = attributes;
+
   }
 
   /**
@@ -42,12 +56,12 @@ public class BiItem {
    * If the attribute is found inside the map the corresponding value will be increased, otherwise the attribute will be
    * put in the map with value 1.
    * If the value found is not an integer, then no update will be performed.
+   *
    * @param attributeName name of the attribute to be increased in value
    */
   protected void increaseAttributeCount(String attributeName) {
-    int value;
     try {
-      value = Integer.parseInt(attributes.getOrDefault(attributeName, "0")) + 1;
+      int value = Integer.parseInt(attributes.getOrDefault(attributeName, "0")) + 1;
       attributes.put(attributeName, String.valueOf(value));
     } catch (NumberFormatException e) {
       logger.warn("Attribute {} for element {} does not contain an integer value. The count will not be increased.",

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
@@ -14,9 +14,9 @@ public class BiItem {
   private static final Logger logger = LoggerFactory.getLogger(BiContext.class);
 
   private final String name;
-  private final Map<String, String> attributes;
+  private final Map<String, Object> attributes;
 
-  public BiItem(String name, Map<String, String> attributes) {
+  public BiItem(String name, Map<String, Object> attributes) {
     this.name = name;
     this.attributes = attributes;
   }
@@ -29,8 +29,8 @@ public class BiItem {
    */
   public BiItem(String name, String attribute) {
     this.name = name;
-    Map<String, String> attributes =  new HashMap<>();
-    attributes.put(attribute, String.valueOf(1));
+    Map<String, Object> attributes =  new HashMap<>();
+    attributes.put(attribute, 1);
     this.attributes = attributes;
 
   }
@@ -48,7 +48,7 @@ public class BiItem {
    * of occurrences for generic attributes of the value or the attribute it self (e.g Button type can be either "action" or "reset").
    * If a specific attribute is not present the respective value will be set to an empty string.
    */
-  public Map<String, String> getAttributes() {
+  public Map<String, Object> getAttributes() {
     return attributes;
   }
 
@@ -61,9 +61,9 @@ public class BiItem {
    */
   protected void increaseAttributeCount(String attributeName) {
     try {
-      int value = Integer.parseInt(attributes.getOrDefault(attributeName, "0")) + 1;
-      attributes.put(attributeName, String.valueOf(value));
-    } catch (NumberFormatException e) {
+      Integer value = (Integer) attributes.getOrDefault(attributeName, 0) + 1;
+      attributes.put(attributeName, value);
+    } catch (ClassCastException e) {
       logger.warn("Attribute {} for element {} does not contain an integer value. The count will not be increased.",
               attributeName, getName());
     }

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
@@ -14,7 +14,7 @@ public class BiItem {
 
   private final String name;
 
-  private Map<String, String> attributes;
+  private final Map<String, String> attributes;
 
   public BiItem(String name, Map<String, String> attributes) {
     this.name = name;
@@ -44,19 +44,14 @@ public class BiItem {
    * If the value found is not an integer, then no update will be performed.
    * @param attributeName name of the attribute to be increased in value
    */
-  protected void increaseAttributeCount(String attributeName){
-    int value = 1;
-    if(attributes.containsKey(attributeName)){
-      String valueFound = attributes.get(attributeName);
-    try{
-        value = Integer.parseInt(valueFound) + 1;
-      } catch (NumberFormatException e){
-        logger.warn("Attribute {} for element {} does not contain an integer value. The count will not be increased.",
-                attributeName, getName());
-        return;
-      }
+  protected void increaseAttributeCount(String attributeName) {
+    int value;
+    try {
+      value = Integer.parseInt(attributes.getOrDefault(attributeName, "0")) + 1;
+      attributes.put(attributeName, String.valueOf(value));
+    } catch (NumberFormatException e) {
+      logger.warn("Attribute {} for element {} does not contain an integer value. The count will not be increased.",
+              attributeName, getName());
     }
-    attributes.put(attributeName, String.valueOf(value));
   }
-
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -133,6 +133,6 @@ public class Button extends FormElement {
     attributesMapBi.put(TYPE_ATTR, getAttributes().getOrDefault(TYPE_ATTR, ""));
     attributesMapBi.put(CLASS_ATTR, getAttributes().getOrDefault(CLASS_ATTR, ""));
     attributesMapBi.put(TooltipableElement.TITLE, getAttributes().containsKey(TooltipableElement.TITLE) ? "1" : StringUtils.EMPTY);
-    context.addItem(new BiItem(getClass().getSimpleName(), attributesMapBi));
+    context.addItem(new BiItem("Button", attributesMapBi));
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -129,10 +129,10 @@ public class Button extends FormElement {
 
   @Override
   public void updateBiContext(BiContext context) {
-    Map<String, String> attributesMapBi = new HashMap<>();
+    Map<String, Object> attributesMapBi = new HashMap<>();
     attributesMapBi.put(TYPE_ATTR, getAttributes().getOrDefault(TYPE_ATTR, ""));
     attributesMapBi.put(CLASS_ATTR, getAttributes().getOrDefault(CLASS_ATTR, ""));
-    attributesMapBi.put(TooltipableElement.TITLE, getAttributes().containsKey(TooltipableElement.TITLE) ? "1" : StringUtils.EMPTY);
+    attributesMapBi.put(TooltipableElement.TITLE, getAttributes().containsKey(TooltipableElement.TITLE) ? 1 : StringUtils.EMPTY);
     context.addItem(new BiItem("Button", attributesMapBi));
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.ButtonNode;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
@@ -12,11 +14,11 @@ import org.w3c.dom.Node;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-
 
 /**
  * Class representing a Symphony Elements button
@@ -123,5 +125,14 @@ public class Button extends FormElement {
 
     assertContentModel(Collections.singleton(TextNode.class));
     assertContainsChildOfType(Collections.singleton(TextNode.class));
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, String> attributesMapBi = new HashMap<>();
+    attributesMapBi.put(TYPE_ATTR, getAttributes().getOrDefault(TYPE_ATTR, ""));
+    attributesMapBi.put(CLASS_ATTR, getAttributes().getOrDefault(CLASS_ATTR, ""));
+    attributesMapBi.put(TooltipableElement.TITLE, getAttributes().containsKey(TooltipableElement.TITLE) ? "1" : StringUtils.EMPTY);
+    context.addItem(new BiItem("Button", attributesMapBi));
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -133,6 +133,6 @@ public class Button extends FormElement {
     attributesMapBi.put(TYPE_ATTR, getAttributes().getOrDefault(TYPE_ATTR, ""));
     attributesMapBi.put(CLASS_ATTR, getAttributes().getOrDefault(CLASS_ATTR, ""));
     attributesMapBi.put(TooltipableElement.TITLE, getAttributes().containsKey(TooltipableElement.TITLE) ? "1" : StringUtils.EMPTY);
-    context.addItem(new BiItem("Button", attributesMapBi));
+    context.addItem(new BiItem(getClass().getSimpleName(), attributesMapBi));
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -116,7 +116,7 @@ public abstract class Element {
    * it is going to create/update a simple BiItem containing the element name and the occurrences.
    */
   void updateBiContext(BiContext context){
-    context.updateItemInContext(getClass().getSimpleName(), getMessageMLTag());
+    context.updateItem(getClass().getSimpleName(), getMessageMLTag());
   }
 
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -19,6 +19,7 @@ package org.symphonyoss.symphony.messageml.elements;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.commonmark.node.Node;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
@@ -84,8 +85,6 @@ public abstract class Element {
   /**
    * Informs if the element has an "id" attribute.
    * The parser that builds all elements keeps track of all ids from the elements that have it, in order to ensure unique values.
-   *
-   * @return
    */
   public Boolean hasIdAttribute() {
     // An element, by default, should not have it.
@@ -102,13 +101,24 @@ public abstract class Element {
     for (int i = 0; i < attr.getLength(); i++) {
       buildAttribute(parser, attr.item(i));
     }
-
+    if(!MessageML.MESSAGEML_TAG.equals(getMessageMLTag())) {
+      updateBiContext(parser.getBiContext());
+    }
     NodeList children = element.getChildNodes();
 
     for (int i = 0; i < children.getLength(); i++) {
       buildNode(parser, children.item(i));
     }
   }
+
+  /**
+   * Update the BiContext adding information about the MessageML element. If not overridden in the element itself
+   * it is going to create/update a simple BiItem containing the element name and the occurrences.
+   */
+  void updateBiContext(BiContext context){
+    context.updateItemInContext(getClass().getSimpleName(), getMessageMLTag());
+  }
+
 
   /**
    * Parse a DOM attribute into MessageML element properties.

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Header.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Header.java
@@ -57,6 +57,6 @@ public class Header extends Element {
 
   @Override
   public void updateBiContext(BiContext context) {
-    context.updateItem(getClass().getSimpleName(), tag);
+    context.updateItem("Header", tag);
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Header.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Header.java
@@ -57,6 +57,6 @@ public class Header extends Element {
 
   @Override
   public void updateBiContext(BiContext context) {
-    context.updateItemInContext(getClass().getSimpleName(), tag);
+    context.updateItem(getClass().getSimpleName(), tag);
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Header.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Header.java
@@ -18,6 +18,7 @@ package org.symphonyoss.symphony.messageml.elements;
 
 import org.commonmark.node.Node;
 import org.commonmark.node.StrongEmphasis;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 
 import java.util.regex.Pattern;
@@ -33,8 +34,11 @@ public class Header extends Element {
   public static final String MESSAGEML_TAG = "h";
   private static final String MARKDOWN = "**";
 
+  private final String tag;
+
   public Header(Element parent, String tag) {
     super(parent, tag);
+    this.tag = tag;
   }
 
   @Override
@@ -49,5 +53,10 @@ public class Header extends Element {
   @Override
   public void validate() throws InvalidInputException {
     assertPhrasingContent();
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    context.updateItemInContext(getClass().getSimpleName(), tag);
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Link.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Link.java
@@ -119,7 +119,7 @@ public class Link extends Element {
 
   @Override
   public void updateBiContext(BiContext biContext){
-    biContext.updateItemInContext(getClass().getSimpleName(), ATTR_HREF);
+    biContext.updateItem(getClass().getSimpleName(), ATTR_HREF);
   }
 
   public URI getUri() {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Link.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Link.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.commonmark.node.Node;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
 import org.symphonyoss.symphony.messageml.util.IDataProvider;
@@ -114,6 +115,11 @@ public class Link extends Element {
       throw new InvalidInputException(e.getMessage());
     }
 
+  }
+
+  @Override
+  public void updateBiContext(BiContext biContext){
+    biContext.updateItemInContext(getClass().getSimpleName(), ATTR_HREF);
   }
 
   public URI getUri() {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Link.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Link.java
@@ -119,7 +119,7 @@ public class Link extends Element {
 
   @Override
   public void updateBiContext(BiContext biContext){
-    biContext.updateItem(getClass().getSimpleName(), ATTR_HREF);
+    biContext.updateItem("Link", ATTR_HREF);
   }
 
   public URI getUri() {

--- a/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
@@ -352,16 +352,16 @@ public class MessageMLContextTest {
     final String message =
             "<messageML>" +
             "    <form id=\"all-elements\">" +
-            "        <button name=\"example-button2\" class=\"primary\" type=\"action\">Button Text</button>" +
+            "        <button name=\"example-button2\" class=\"primary\" type=\"action\"  title =\"This is a title\">Button Text</button>" +
             "    </form>" +
             "</messageML>";
 
-    Map<String, String> expectedFormAttrs = new HashMap<>();
-    expectedFormAttrs.put("form", "1");
-    Map<String, String> expectedButtonAttrs = new HashMap<>();
+    Map<String, Object> expectedFormAttrs = new HashMap<>();
+    expectedFormAttrs.put("form", 1);
+    Map<String, Object> expectedButtonAttrs = new HashMap<>();
     expectedButtonAttrs.put("class", "primary");
     expectedButtonAttrs.put("type", "action");
-    expectedButtonAttrs.put("title", "");
+    expectedButtonAttrs.put("title", 1);
 
     context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
     BiContext biContext = context.getBiContext();
@@ -383,17 +383,24 @@ public class MessageMLContextTest {
             "<messageML>" +
             "    <form id=\"all-elements\">" +
             "        <text-field name=\"text-field\" placeholder=\"placeholder-here\" title=\"title-here\" label=\"label-here\">test_underscore</text-field>" +
-            "        <button name=\"example-button2\" class=\"primary\" type=\"action\" title =\"This is a title\">Button Text</button>" +
+            "        <button name=\"example-button2\" class=\"primary\" type=\"action\">Button Text</button>" +
             "    </form>" +
             "</messageML>";
 
     context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
     BiContext biContext = context.getBiContext();
 
+    Map<String, Object> expectedButtonAttrs = new HashMap<>();
+    expectedButtonAttrs.put("class", "primary");
+    expectedButtonAttrs.put("type", "action");
+    expectedButtonAttrs.put("title", "");
+
     assertEquals(3, biContext.getItems().size());
     assertEquals("Form", biContext.getItems().get(0).getName());
     assertEquals("TextField", biContext.getItems().get(1).getName());
-    assertEquals("Button", biContext.getItems().get(2).getName());
+    BiItem buttonItem = biContext.getItems().get(2);
+    assertEquals("Button", buttonItem.getName());
+    assertEquals(expectedButtonAttrs, buttonItem.getAttributes());
   }
 
   @Test
@@ -424,10 +431,10 @@ public class MessageMLContextTest {
               "<emoji shortcode=\"smiley\"/>" +
             "</messageML>";
 
-    Map<String, String> expectedLinkAttrs = new HashMap<>();
-    expectedLinkAttrs.put("href", "2");
-    Map<String, String> expectedEmojisAttrs = new HashMap<>();
-    expectedEmojisAttrs.put("emoji", "1");
+    Map<String, Object> expectedLinkAttrs = new HashMap<>();
+    expectedLinkAttrs.put("href", 2);
+    Map<String, Object> expectedEmojisAttrs = new HashMap<>();
+    expectedEmojisAttrs.put("emoji", 1);
 
     context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
     BiContext biContext = context.getBiContext();
@@ -454,10 +461,10 @@ public class MessageMLContextTest {
               "<h5>Hello world!</h5>" +
             "</messageML>";
 
-    Map<String, String> expectedHeadersAttributes = new HashMap<>();
-    expectedHeadersAttributes.put("h1", "1");
-    expectedHeadersAttributes.put("h2","2");
-    expectedHeadersAttributes.put("h5", "1");
+    Map<String, Object> expectedHeadersAttributes = new HashMap<>();
+    expectedHeadersAttributes.put("h1", 1);
+    expectedHeadersAttributes.put("h2",2);
+    expectedHeadersAttributes.put("h5", 1);
 
     context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
     BiContext biContext = context.getBiContext();

--- a/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
@@ -342,9 +342,21 @@ public class MessageMLContextTest {
 
   @Test
   public void testGetBiContextBeforeParsing() {
-    assertThrows(IllegalStateException.class, () -> {
-      context.getBiContext();
-    });
+    BiContext biContext = context.getBiContext();
+
+    assertFalse(biContext.getLibraryVersion().isEmpty());
+    assertTrue(biContext.getItems().isEmpty());
+  }
+
+  @Test
+  public void testGetBiContextWhenOnlyPlainText() throws InvalidInputException, IOException, ProcessingException {
+    final String message = "<messageML>Hello World!</messageML>";
+
+    context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
+    BiContext biContext = context.getBiContext();
+
+    assertFalse(biContext.getLibraryVersion().isEmpty());
+    assertTrue(biContext.getItems().isEmpty());
   }
 
   @Test

--- a/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
@@ -19,6 +19,7 @@ package org.symphonyoss.symphony.messageml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyLong;
@@ -33,10 +34,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.BulletList;
 import org.symphonyoss.symphony.messageml.elements.CashTag;
 import org.symphonyoss.symphony.messageml.elements.Element;
@@ -56,6 +58,7 @@ import org.xml.sax.InputSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -335,6 +338,134 @@ public class MessageMLContextTest {
                     "</div>", id1, id1, id2, id2);
 
     assertEquals(expectedResult, presentationML);
+  }
+
+  @Test
+  public void testGetBiContextBeforeParsing() {
+    assertThrows(IllegalStateException.class, () -> {
+      context.getBiContext();
+    });
+  }
+
+  @Test
+  public void testGetBiContextWithOneElementInForm() throws InvalidInputException, IOException, ProcessingException {
+    final String message =
+            "<messageML>" +
+            "    <form id=\"all-elements\">" +
+            "        <button name=\"example-button2\" class=\"primary\" type=\"action\">Button Text</button>" +
+            "    </form>" +
+            "</messageML>";
+
+    Map<String, String> expectedFormAttrs = new HashMap<>();
+    expectedFormAttrs.put("form", "1");
+    Map<String, String> expectedButtonAttrs = new HashMap<>();
+    expectedButtonAttrs.put("class", "primary");
+    expectedButtonAttrs.put("type", "action");
+    expectedButtonAttrs.put("title", "");
+
+    context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
+    BiContext biContext = context.getBiContext();
+
+    assertEquals(2, biContext.getItems().size());
+
+    BiItem formItem = biContext.getItems().get(0);
+    assertEquals("Form", formItem.getName());
+    assertEquals(expectedFormAttrs , formItem.getAttributes());
+
+    BiItem buttonItem = biContext.getItems().get(1);
+    assertEquals("Button", buttonItem.getName());
+    assertEquals(expectedButtonAttrs , buttonItem.getAttributes());
+  }
+
+  @Test
+  public void testGetBiContextWithDifferentElementsInForm() throws InvalidInputException, IOException, ProcessingException {
+    final String message =
+            "<messageML>" +
+            "    <form id=\"all-elements\">" +
+            "        <text-field name=\"text-field\" placeholder=\"placeholder-here\" title=\"title-here\" label=\"label-here\">test_underscore</text-field>" +
+            "        <button name=\"example-button2\" class=\"primary\" type=\"action\" title =\"This is a title\">Button Text</button>" +
+            "    </form>" +
+            "</messageML>";
+
+    context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
+    BiContext biContext = context.getBiContext();
+
+    assertEquals(3, biContext.getItems().size());
+    assertEquals("Form", biContext.getItems().get(0).getName());
+    assertEquals("TextField", biContext.getItems().get(1).getName());
+    assertEquals("Button", biContext.getItems().get(2).getName());
+  }
+
+  @Test
+  public void testGetBiContextWithSameElementsInForm() throws InvalidInputException, IOException, ProcessingException {
+    final String message =
+            "<messageML>" +
+            "    <form id=\"all-elements\">" +
+            "        <button name=\"example-button2\" class=\"primary\" type=\"action\" title =\"This is a title\">Button Text</button>" +
+            "        <button name=\"example-button2\" class=\"primary\" type=\"action\">Button Text</button>" +
+            "    </form>" +
+            "</messageML>";
+
+    context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
+    BiContext biContext = context.getBiContext();
+
+    assertEquals(3, biContext.getItems().size());
+    assertEquals("Form", biContext.getItems().get(0).getName());
+    assertEquals("Button", biContext.getItems().get(1).getName());
+    assertEquals("Button", biContext.getItems().get(2).getName());
+  }
+
+  @Test
+  public void testGetBiContextDuplicateSimpleTags() throws InvalidInputException, IOException, ProcessingException {
+    final String message =
+            "<messageML>" +
+              "<a href=\"https://hello.org\">Hello world!</a>" +
+              "<a href=\"http:google.com\">Google!</a>" +
+              "<emoji shortcode=\"smiley\"/>" +
+            "</messageML>";
+
+    Map<String, String> expectedLinkAttrs = new HashMap<>();
+    expectedLinkAttrs.put("href", "2");
+    Map<String, String> expectedEmojisAttrs = new HashMap<>();
+    expectedEmojisAttrs.put("emoji", "1");
+
+    context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
+    BiContext biContext = context.getBiContext();
+
+    List<BiItem> biItems = biContext.getItems();
+    assertEquals(2, biItems.size());
+
+    BiItem linkItem = biItems.get(0);
+    assertEquals("Link", linkItem.getName());
+    assertEquals(expectedLinkAttrs, linkItem.getAttributes());
+
+    BiItem emojiItem = biItems.get(1);
+    assertEquals("Emoji", biItems.get(1).getName());
+    assertEquals(expectedEmojisAttrs, emojiItem.getAttributes());
+  }
+
+  @Test
+  public void testGetBiContextWithMultipleHeaders() throws InvalidInputException, IOException, ProcessingException {
+    final String message =
+            "<messageML>" +
+              "<h1>Hello world!</h1>" +
+              "<h2>Hello world!</h2>" +
+              "<h2>Hello world!</h2>" +
+              "<h5>Hello world!</h5>" +
+            "</messageML>";
+
+    Map<String, String> expectedHeadersAttributes = new HashMap<>();
+    expectedHeadersAttributes.put("h1", "1");
+    expectedHeadersAttributes.put("h2","2");
+    expectedHeadersAttributes.put("h5", "1");
+
+    context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
+    BiContext biContext = context.getBiContext();
+
+    List<BiItem> biItems = biContext.getItems();
+    assertEquals(1, biItems.size());
+    assertEquals("Header", biItems.get(0).getName());
+    assertEquals(expectedHeadersAttributes, biItems.get(0).getAttributes());
   }
 
   @Test

--- a/src/test/java/org/symphonyoss/symphony/messageml/bi/BiContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/bi/BiContextTest.java
@@ -25,7 +25,7 @@ public class BiContextTest {
 
   @Test
   public void testUpdateItemInContextWhenItemNotFound() {
-    biContext.updateItemInContext("Link", "href");
+    biContext.updateItem("Link", "href");
 
     assertEquals(1, biContext.getItems().size());
 
@@ -41,7 +41,7 @@ public class BiContextTest {
     BiItem headerItem = new BiItem("Link", linkAttrs);
     biContext.addItem(headerItem);
 
-    biContext.updateItemInContext("Link", "href");
+    biContext.updateItem("Link", "href");
 
     assertEquals(1, biContext.getItems().size());
 
@@ -58,7 +58,7 @@ public class BiContextTest {
     BiItem headerItem = new BiItem("Header", headerAttrs);
     biContext.addItem(headerItem);
 
-    biContext.updateItemInContext("Header", "h1");
+    biContext.updateItem("Header", "h1");
 
     assertEquals(1, biContext.getItems().size());
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/bi/BiContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/bi/BiContextTest.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 public class BiContextTest {
 
@@ -31,8 +30,8 @@ public class BiContextTest {
 
   @Test
   public void testUpdateItemInContextWhenItemAndAttributeFound() {
-    Map<String, String> linkAttrs = new HashMap<>();
-    linkAttrs.put("href", "1");
+    Map<String, Object> linkAttrs = new HashMap<>();
+    linkAttrs.put("href", 1);
     BiItem headerItem = new BiItem("Link", linkAttrs);
     biContext.addItem(headerItem);
 
@@ -47,9 +46,9 @@ public class BiContextTest {
 
   @Test
   public void testUpdateItemInContextWhenMultipleAttrsItemFound() {
-    Map<String, String> headerAttrs = new HashMap<>();
-    headerAttrs.put("h1", "2");
-    headerAttrs.put("h3", "1");
+    Map<String, Object> headerAttrs = new HashMap<>();
+    headerAttrs.put("h1", 2);
+    headerAttrs.put("h3", 1);
     BiItem headerItem = new BiItem("Header", headerAttrs);
     biContext.addItem(headerItem);
 
@@ -63,10 +62,10 @@ public class BiContextTest {
 
   }
 
-  private Map<String, String> expectedMap() {
-    Map<String, String> expected = new HashMap<>();
-    expected.put("h1", "3");
-    expected.put("h3", "1");
+  private Map<String, Object> expectedMap() {
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("h1", 3);
+    expected.put("h3", 1);
     return expected;
   }
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/bi/BiContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/bi/BiContextTest.java
@@ -1,0 +1,78 @@
+package org.symphonyoss.symphony.messageml.bi;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class BiContextTest {
+
+  public BiContext biContext;
+
+  @Before
+  public void setUp(){
+    biContext = new BiContext();
+  }
+
+  @Test
+  public void testGetLibraryVersion() {
+    assertFalse(biContext.getLibraryVersion().isEmpty());
+  }
+
+  @Test
+  public void testUpdateItemInContextWhenItemNotFound() {
+    biContext.updateItemInContext("Link", "href");
+
+    assertEquals(1, biContext.getItems().size());
+
+    BiItem biItem = biContext.getItems().get(0);
+    assertEquals("Link", biItem.getName());
+    assertEquals("{href=1}", biItem.getAttributes().toString());
+  }
+
+  @Test
+  public void testUpdateItemInContextWhenItemAndAttributeFound() {
+    Map<String, String> linkAttrs = new HashMap<>();
+    linkAttrs.put("href", "1");
+    BiItem headerItem = new BiItem("Link", linkAttrs);
+    biContext.addItem(headerItem);
+
+    biContext.updateItemInContext("Link", "href");
+
+    assertEquals(1, biContext.getItems().size());
+
+    BiItem biItem = biContext.getItems().get(0);
+    assertEquals("Link", biItem.getName());
+    assertEquals("{href=2}", biItem.getAttributes().toString());
+  }
+
+  @Test
+  public void testUpdateItemInContextWhenMultipleAttrsItemFound() {
+    Map<String, String> headerAttrs = new HashMap<>();
+    headerAttrs.put("h1", "2");
+    headerAttrs.put("h3", "1");
+    BiItem headerItem = new BiItem("Header", headerAttrs);
+    biContext.addItem(headerItem);
+
+    biContext.updateItemInContext("Header", "h1");
+
+    assertEquals(1, biContext.getItems().size());
+
+    BiItem biItem = biContext.getItems().get(0);
+    assertEquals("Header", biItem.getName());
+    assertEquals(expectedMap(), biItem.getAttributes());
+
+  }
+
+  private Map<String, String> expectedMap() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("h1", "3");
+    expected.put("h3", "1");
+    return expected;
+  }
+
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/bi/BiContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/bi/BiContextTest.java
@@ -19,11 +19,6 @@ public class BiContextTest {
   }
 
   @Test
-  public void testGetLibraryVersion() {
-    assertFalse(biContext.getLibraryVersion().isEmpty());
-  }
-
-  @Test
   public void testUpdateItemInContextWhenItemNotFound() {
     biContext.updateItem("Link", "href");
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/bi/BiItemTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/bi/BiItemTest.java
@@ -1,0 +1,50 @@
+package org.symphonyoss.symphony.messageml.bi;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BiItemTest {
+
+  @Test
+  public void testIncreaseAttributeCountWhenAttributeNotFound() {
+    String attributeName = "attribute1";
+    BiItem biItem = new BiItem("element1", new HashMap<>());
+    biItem.increaseAttributeCount(attributeName);
+
+    assertEquals(1, biItem.getAttributes().size());
+    assertTrue(biItem.getAttributes().containsKey(attributeName));
+    assertEquals("1", biItem.getAttributes().get(attributeName));
+  }
+
+  @Test
+  public void testIncreaseAttributeCountWhenAttributeFound() {
+    String attributeName = "attribute1";
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(attributeName, "3");
+    BiItem biItem = new BiItem("element1", attributes);
+    biItem.increaseAttributeCount(attributeName);
+
+    assertEquals(1, biItem.getAttributes().size());
+    assertTrue(biItem.getAttributes().containsKey(attributeName));
+    assertEquals("4", biItem.getAttributes().get(attributeName));
+  }
+
+  @Test
+  public void testIncreaseAttributeCountWhenInvalidFormat() {
+    String attributeName = "attribute1";
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(attributeName, "notInteger");
+    BiItem biItem = new BiItem("element1", attributes);
+    biItem.increaseAttributeCount(attributeName);
+
+    //nothing should change
+    assertEquals(1, biItem.getAttributes().size());
+    assertTrue(biItem.getAttributes().containsKey(attributeName));
+    assertEquals("notInteger", biItem.getAttributes().get(attributeName));
+  }
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/bi/BiItemTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/bi/BiItemTest.java
@@ -18,26 +18,26 @@ public class BiItemTest {
 
     assertEquals(1, biItem.getAttributes().size());
     assertTrue(biItem.getAttributes().containsKey(attributeName));
-    assertEquals("1", biItem.getAttributes().get(attributeName));
+    assertEquals(1, biItem.getAttributes().get(attributeName));
   }
 
   @Test
   public void testIncreaseAttributeCountWhenAttributeFound() {
     String attributeName = "attribute1";
-    Map<String, String> attributes = new HashMap<>();
-    attributes.put(attributeName, "3");
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put(attributeName, 3);
     BiItem biItem = new BiItem("element1", attributes);
     biItem.increaseAttributeCount(attributeName);
 
     assertEquals(1, biItem.getAttributes().size());
     assertTrue(biItem.getAttributes().containsKey(attributeName));
-    assertEquals("4", biItem.getAttributes().get(attributeName));
+    assertEquals(4, biItem.getAttributes().get(attributeName));
   }
 
   @Test
   public void testIncreaseAttributeCountWhenInvalidFormat() {
     String attributeName = "attribute1";
-    Map<String, String> attributes = new HashMap<>();
+    Map<String, Object> attributes = new HashMap<>();
     attributes.put(attributeName, "notInteger");
     BiItem biItem = new BiItem("element1", attributes);
     biItem.increaseAttributeCount(attributeName);


### PR DESCRIPTION
Goal of this PR is to set up a framework in order to be able collect BI events.
The BiContext is the main object which contains a list of BiItems (one per element found inside the messageML). While parsing the MessageML the BiContext will be initialised and automatically filled with all the information.

Each element will create a new BiItem which is composed by the element name and a map of all attributes found. To customise this item each element can override the updateBiContext() method of Element class and define the map as needed. 
For now the function is by default creating a simple item which counts the occurrences of the element inside the message. An example of custom biItem can be found in the Button class.

With the updateBiContext() inside element we will already get some BiItems for free like the: Link, Code, Pre, Span (Full list to be checked in the next implementations ticket)

Example on how to get the BiContext for a message
```
MessageMLContext context = new MessageMLContext(null);
context.parseMessageML("<messageML>Hello world!</messageML>", null , "v2");
// retrieve the BI Context populated while MessageML parsing
BiContext biContext = context.getBiContext();
```