### PR TITLE
MML-261 Adding new UIAction tag in MessageML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.jar.version>3.1.2</maven.jar.version>
         <jsonassert.version>1.5.0</jsonassert.version>
+        <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
     <profiles>
@@ -285,7 +286,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.atlassian.commonmark</groupId>

--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -70,6 +70,7 @@ import org.symphonyoss.symphony.messageml.elements.TextField;
 import org.symphonyoss.symphony.messageml.elements.TimePicker;
 import org.symphonyoss.symphony.messageml.elements.TimezonePicker;
 import org.symphonyoss.symphony.messageml.elements.TooltipableElement;
+import org.symphonyoss.symphony.messageml.elements.UIAction;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
 import org.symphonyoss.symphony.messageml.util.IDataProvider;
@@ -524,6 +525,9 @@ public class MessageMLParser {
 
       case TextArea.MESSAGEML_TAG:
         return new TextArea(parent, messageFormat);
+
+      case UIAction.MESSAGEML_TAG:
+        return new UIAction(parent, messageFormat);
 
       case LabelableElement.LABEL:
         String id = getAttribute(element, LabelableElement.LABEL_FOR);

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
@@ -1,7 +1,6 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
@@ -43,13 +42,10 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
   private static final String HIGHLIGHTED_DATE_PRESENTATION_ATTR = "data-highlighted-date";
   private static final String FORMAT_PRESENTATION_ATTR = "data-format";
 
-  private final ObjectMapper mapper;
-
   private static final String DATE_FORMAT_ALLOWED = "^[0-9Mdy\\/. -:]+$";
 
   public DatePicker(Element parent, FormatEnum format) {
     super(parent, MESSAGEML_TAG, format);
-    mapper = new ObjectMapper();
   }
 
   @Override
@@ -199,8 +195,8 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
    */
   private XMLAttribute convertJsonDateToPresentationML(String attributeName) {
     try {
-      DateInterval[] dateIntervals = mapper.readValue(getAttribute(attributeName), DateInterval[].class);
-      String result = mapper.writeValueAsString(dateIntervals);
+      DateInterval[] dateIntervals = MAPPER.readValue(getAttribute(attributeName), DateInterval[].class);
+      String result = MAPPER.writeValueAsString(dateIntervals);
       return XMLAttribute.of(result, XMLAttribute.Format.JSON);
     } catch (JsonProcessingException e) {
       // this exception should never happens because this method is called after validation
@@ -223,7 +219,7 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
                 DATE_RANGE_MAX_LENGTH));
       }
       try {
-        DateInterval[] dateIntervals = mapper.readValue(attributeValue, DateInterval[].class);
+        DateInterval[] dateIntervals = MAPPER.readValue(attributeValue, DateInterval[].class);
         for(DateInterval dateInterval:dateIntervals){
           dateInterval.assertIsValid();
         }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DateSelector.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DateSelector.java
@@ -27,7 +27,6 @@ public class DateSelector extends FormElement {
 
   private static final String PLACEHOLDER_ATTR = "placeholder";
   private static final String REQUIRED_ATTR = "required";
-  private static final Set<String> VALID_VALUES_FOR_REQUIRED_ATTR = new HashSet<>(Arrays.asList("true", "false"));
 
   private static final String PRESENTATIONML_NAME_ATTR = "data-name";
   private static final String PRESENTATIONML_PLACEHOLDER_ATTR = "data-placeholder";
@@ -59,13 +58,11 @@ public class DateSelector extends FormElement {
   @Override
   public void validate() throws InvalidInputException {
     super.validate();
-
-    if (getAttribute(NAME_ATTR) == null) {
-      throw new InvalidInputException("The attribute \"name\" is required");
-    }
-
+    
+    assertAttributeNotBlank(NAME_ATTR);
+    
     if(getAttribute(REQUIRED_ATTR) != null) {
-      assertAttributeValue(REQUIRED_ATTR, VALID_VALUES_FOR_REQUIRED_ATTR);
+      assertAttributeIsBoolean(REQUIRED_ATTR);
     }
 
     assertNoContent();

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -16,6 +16,7 @@
 
 package org.symphonyoss.symphony.messageml.elements;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.commonmark.node.Node;
@@ -69,6 +70,9 @@ public abstract class Element {
   private final List<Element> children = new ArrayList<>();
   private final Element parent;
   private final String messageMLTag;
+
+  private static final Set<String> VALID_BOOLEAN_VALUES = new HashSet<>(Arrays.asList("true", "false"));
+  public static final ObjectMapper MAPPER = new ObjectMapper();
 
   Element(Element parent) {
     this(parent, null);
@@ -400,8 +404,7 @@ public abstract class Element {
    * @throws InvalidInputException when invalid boolean is found
    */
   void assertAttributeIsBoolean(String attributeName) throws InvalidInputException {
-    Set<String> allowedValues = new HashSet<>(Arrays.asList("true", "false"));
-    assertAttributeValue(attributeName, allowedValues);
+    assertAttributeValue(attributeName, VALID_BOOLEAN_VALUES);
   }
 
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -38,10 +38,12 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -257,7 +259,7 @@ public abstract class Element {
     }
 
     if(this instanceof SplittableElement && ((SplittableElement) this).isSplittable()){
-      ((SplittableElement)this).splittableRemove().forEach(remove -> attributes.remove(remove));
+      ((SplittableElement)this).splittableRemove().forEach(attributes::remove);
       // open div + adding splittable elements
       String uid = ((SplittableElement)this).splittableAsPresentationML(out, context);
       attributes.put("id", uid);
@@ -381,7 +383,7 @@ public abstract class Element {
    *
    * @param attributeName name of attribute that will be checked.
    * @param permittedValues list of values that are allowed for the specified attribute
-   * @throws InvalidInputException
+   * @throws InvalidInputException when invalid value is found
    */
   void assertAttributeValue(String attributeName, Collection<String> permittedValues) throws InvalidInputException {
     String attributeValue = getAttribute(attributeName);
@@ -393,11 +395,22 @@ public abstract class Element {
   }
 
   /**
+   * Checks if the attribute value is a valid boolean
+   * @param attributeName name of attribute that will be checked.
+   * @throws InvalidInputException when invalid boolean is found
+   */
+  void assertAttributeIsBoolean(String attributeName) throws InvalidInputException {
+    Set<String> allowedValues = new HashSet<>(Arrays.asList("true", "false"));
+    assertAttributeValue(attributeName, allowedValues);
+  }
+
+
+  /**
    * Checks if attribute contains a date, in the provided format
    *
    * @param attributeName name of attribute that will be checked.
    * @param formatter date format
-   * @throws InvalidInputException
+   * @throws InvalidInputException when invalid format found
    */
   void assertDateFormat(String attributeName, DateTimeFormatter formatter)
       throws InvalidInputException {
@@ -415,7 +428,7 @@ public abstract class Element {
    *
    * @param attributeName name of attribute that will be checked.
    * @param formatter time format
-   * @throws InvalidInputException
+   * @throws InvalidInputException when invalid format found
    */
   void assertTimeFormat(String attributeName, DateTimeFormatter formatter)
           throws InvalidInputException {
@@ -434,7 +447,7 @@ public abstract class Element {
    * Checks if an attribute is not null or empty
    *
    * @param attributeName name of attribute that will be checked.
-   * @throws InvalidInputException
+   * @throws InvalidInputException when attribute null or empty
    */
   void assertAttributeNotBlank(String attributeName) throws InvalidInputException {
     String attributeValue = getAttribute(attributeName);
@@ -447,9 +460,9 @@ public abstract class Element {
   /**
    * Checks if an attribute length is bigger than allowed
    *
-   * @param attributeName
-   * @param maxLength
-   * @throws InvalidInputException
+   * @param attributeName name of attribute that will be checked.
+   * @param maxLength maximum length allowed
+   * @throws InvalidInputException when maxLength exceeded
    */
   void assertAttributeMaxLength(String attributeName, int maxLength) throws InvalidInputException {
     String attributeValue = getAttribute(attributeName);
@@ -490,7 +503,6 @@ public abstract class Element {
 
   /**
    * Check that the element's children are limited to phrasing content.
-   * @throws InvalidInputException
    */
   void assertPhrasingContent() throws InvalidInputException {
     assertContentModel(Arrays.asList(TextNode.class, Link.class, Chime.class, Bold.class, Italic.class, Image.class,
@@ -565,7 +577,7 @@ public abstract class Element {
    * This is to enforce that at least one child of the element has one of the types informed.
    *
    * @param elementTypes list of element types to check
-   * @throws InvalidInputException
+   * @throws InvalidInputException when no child of allowed type is found
    */
   void assertContainsChildOfType(Collection<Class<? extends Element>> elementTypes) throws InvalidInputException {
     boolean hasPermittedElementAsChild = this.getChildren().stream()
@@ -578,11 +590,27 @@ public abstract class Element {
   }
 
   /**
+   * Assert that the element contains at least one child and that this child is one of the allowed types.
+   *
+   * @param elementTypes list of the allowed element types to check
+   * @throws InvalidInputException when no child of allowed type is found or no child at all found
+   */
+  void assertContainsAlwaysChildOfType(Collection<Class<? extends Element>> elementTypes) throws InvalidInputException {
+    boolean hasPermittedElementAsChild = this.getChildren().stream()
+            .anyMatch(element -> elementTypes.contains(element.getClass()));
+
+    if (this.getChildren().isEmpty() || !hasPermittedElementAsChild) {
+      throw new InvalidInputException(String.format("The \"%s\" element must have at least one child that is any of the following elements: [%s].",
+              getMessageMLTag(), getElementsNameByClassName(elementTypes)));
+    }
+  }
+
+  /**
    * Assert that children with any of the informed types do not exceed the maximum count allowed.
    *
    * @param elementTypes The element types that will be verified in order to ensure that the maximum count was not exceed.
    * @param maxCountPerElementType the maximum quantity, per element type, that is allowed.
-   * @throws InvalidInputException
+   * @throws InvalidInputException when more children than allowed are found
    */
   void assertChildrenNotExceedingMaxCount(Collection<Class<? extends Element>> elementTypes, int maxCountPerElementType) throws InvalidInputException {
     boolean hasExceeded = elementTypes.stream().anyMatch(type -> findElements(type).size() > maxCountPerElementType);
@@ -777,12 +805,12 @@ public abstract class Element {
   /**
    * Check if the element has one of informed element types as a parent at any level.
    *
-   * @param possibleParents
+   * @param possibleParents list of allowed parents
    * @return true if contains; false otherwise.
    */
   private Boolean hasParentAtAnyLevel(Collection<Class<? extends Element>> possibleParents) {
     Element element = this;
-    Boolean parentFound = false;
+    boolean parentFound = false;
 
     while (!parentFound && element.getParent() != null) {
       if (possibleParents.contains(element.getParent().getClass())) {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Form.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Form.java
@@ -51,12 +51,10 @@ public class Form extends Element {
   @Override
   protected void buildAttribute(MessageMLParser parser,
       Node item) throws InvalidInputException {
-    switch (item.getNodeName()) {
-      case ID_ATTR:
-        setAttribute(ID_ATTR, getStringAttribute(item));
-        break;
-      default:
-        throwInvalidInputException(item);
+    if (ID_ATTR.equals(item.getNodeName())) {
+      setAttribute(ID_ATTR, getStringAttribute(item));
+    } else {
+      throwInvalidInputException(item);
     }
   }
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TimePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TimePicker.java
@@ -1,7 +1,6 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
@@ -45,12 +44,9 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
   private static final String FORMAT_ATTR_PATTERN = "^[hHmsa: ]+$";
   private static final String TIME_FORMAT_ALLOWED = "HH:mm:ss";
 
-  private final ObjectMapper mapper;
-
 
   public TimePicker(Element parent, FormatEnum format) {
     super(parent, MESSAGEML_TAG, format);
-    mapper = new ObjectMapper();
   }
 
   @Override
@@ -151,7 +147,7 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
                       DISABLED_TIME_RANGE_MAX_LENGTH));
     }
     try {
-      TimeInterval[] timeIntervals = mapper.readValue(disabledTime, TimeInterval[].class);
+      TimeInterval[] timeIntervals = MAPPER.readValue(disabledTime, TimeInterval[].class);
       for (TimeInterval timeInterval : timeIntervals) {
         timeInterval.assertIsValid();
       }
@@ -246,8 +242,8 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
    */
   private XMLAttribute convertJsonTimeToPresentationML(String attributeName) {
     try {
-      TimeInterval[] timeIntervals = mapper.readValue(getAttribute(attributeName), TimeInterval[].class);
-      String result = mapper.writeValueAsString(timeIntervals);
+      TimeInterval[] timeIntervals = MAPPER.readValue(getAttribute(attributeName), TimeInterval[].class);
+      String result = MAPPER.writeValueAsString(timeIntervals);
       return XMLAttribute.of(result, XMLAttribute.Format.JSON);
     } catch (JsonProcessingException e) {
       // this exception should never happens because this method is called after validation

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TimezonePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TimezonePicker.java
@@ -1,7 +1,6 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
@@ -51,8 +50,6 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
   private static final int DISABLED_TIMEZONE_MAX_LENGTH = 1024;
   private static final String PRESENTATIONML_TAG = "div";
   private static final String CLASS_ATTR = "class";
-
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   public TimezonePicker(Element parent, FormatEnum format) {
     super(parent, MESSAGEML_TAG, format);

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/UIAction.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/UIAction.java
@@ -1,0 +1,167 @@
+package org.symphonyoss.symphony.messageml.elements;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class specify the Symphony Component UIAction which is represented by the tag name "ui-action".
+ * The messageML representation of this element can contain the following fields:
+ * <ul>
+ *   <li>trigger  -> default 'click', trigger of the action. For now only 'click' is supported</li>
+ *   <li>action (required) -> action that can be executed on trigger. For now only 'open-im' is supported</li>
+ * </ul>
+ * The open-im action can support the following attributes:
+ * <ul>
+ *   <li>user-ids (exclusive with stream-id)-> list of the users we want the action to be applied on</li>
+ *   <li>stream-id (exclusive with user-ids) -> stream we want the action to be applied on</li>
+ *   <li>side-by-side -> default true, open the result chat in a new module and keeps the parent one open side by side.
+ *                     If false, the parent one will be replaced.</li>
+ * <ul/>
+ * For now only Buttons and other UIActions will be allowed as child of a ui-action.
+ */
+
+public class UIAction extends Element {
+
+  public static final String MESSAGEML_TAG = "ui-action";
+
+  private static final String TRIGGER_ATTR = "trigger";
+  private static final String ACTION_ATTR = "action";
+  private static final String USER_IDS_ATTR = "user-ids";
+  private static final String STREAM_ID_ATTR = "stream-id";
+  private static final String SIDE_BY_SIDE_ATTR = "side-by-side";
+
+  private static final String DEFAULT_TRIGGER = "click";
+  private static final String ALLOWED_ACTION = "open-im";
+  private static final int MAX_USER_IDS = 15;
+
+  private static final String PRESENTATIONML_TAG = "div";
+  private static final String PRESENTATIONML_ACTION_ATTR = "data-action";
+  private static final String PRESENTATIONML_TRIGGER_ATTR = "data-trigger";
+  private static final String PRESENTATIONML_USER_IDS_ATTR = "data-user-ids";
+  private static final String PRESENTATIONML_STREAM_ID_ATTR = "data-stream-id";
+  private static final String PRESENTATIONML_SIDE_BY_SIDE_ATTR = "data-side-by-side";
+
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  public UIAction(Element parent, FormatEnum format) {
+    super(parent, MESSAGEML_TAG, format);
+    setAttribute(TRIGGER_ATTR, DEFAULT_TRIGGER);
+  }
+
+  @Override
+  protected void buildAttribute(MessageMLParser parser, org.w3c.dom.Node item) throws InvalidInputException {
+    switch (item.getNodeName()) {
+      case ACTION_ATTR:
+      case TRIGGER_ATTR:
+      case USER_IDS_ATTR:
+      case STREAM_ID_ATTR:
+      case SIDE_BY_SIDE_ATTR:
+        if (this.format != FormatEnum.MESSAGEML) {
+          throwInvalidInputException(item);
+        }
+        setAttribute(item.getNodeName(), getStringAttribute(item));
+        break;
+      default:
+        throwInvalidInputException(item);
+    }
+  }
+
+  @Override
+  public void validate() throws InvalidInputException {
+    assertUIActionAllowedChildren();
+
+    assertAttributeNotBlank(ACTION_ATTR);
+    assertAttributeValue(ACTION_ATTR, Collections.singleton(ALLOWED_ACTION));
+    // validate attributes specific to the 'open-im' action
+    validateOpenChatActionAttributes();
+
+    if(getAttribute(TRIGGER_ATTR) != null) {
+      assertAttributeValue(TRIGGER_ATTR, Collections.singleton(DEFAULT_TRIGGER));
+    }
+  }
+
+  private void validateOpenChatActionAttributes() throws InvalidInputException {
+    if(getAttribute(SIDE_BY_SIDE_ATTR) != null) {
+      assertAttributeIsBoolean(SIDE_BY_SIDE_ATTR);
+    }
+    if (getAttribute(USER_IDS_ATTR) != null && getAttribute(STREAM_ID_ATTR) != null) {
+      throw new InvalidInputException("Only one between \"stream-id\" and \"user-ids\" is allowed");
+    }
+    if (getAttribute(USER_IDS_ATTR) == null && getAttribute(STREAM_ID_ATTR) == null) {
+      throw new InvalidInputException("At least one between \"stream-id\" and \"user-ids\" should be present");
+    }
+    validateUserIdsAttribute();
+  }
+
+  private void assertUIActionAllowedChildren() throws InvalidInputException {
+    List<Class<? extends Element>> allowedChildren = Arrays.asList(Button.class, UIAction.class);
+    assertContentModel(allowedChildren);
+    assertContainsAlwaysChildOfType(allowedChildren);
+  }
+
+  @Override
+  void asPresentationML(XmlPrintStream out, MessageMLContext context) {
+    Map<String, String> presentationAttrs = buildAUIActionAttributes();
+    out.openElement(getPresentationMLTag(), presentationAttrs);
+    for (Element child : getChildren()) {
+      child.asPresentationML(out, context);
+    }
+    out.closeElement();
+  }
+
+  @Override
+  public String getPresentationMLTag() {
+    return PRESENTATIONML_TAG;
+  }
+
+  private void validateUserIdsAttribute() throws InvalidInputException {
+    String userIds = getAttribute(USER_IDS_ATTR);
+    List<Long> userIdsList = new ArrayList<>();
+    if (userIds != null) {
+      try {
+        userIdsList = MAPPER.readValue(userIds, MAPPER.getTypeFactory().constructCollectionType(List.class, Long.class));
+      } catch (JsonProcessingException e) {
+        throw new InvalidInputException("Attribute \"user-ids\" contains an unsupported format, should be an array of user ids");
+      }
+    }
+    if(userIdsList.size() > MAX_USER_IDS){
+      throw new InvalidInputException("Attribute \"user-ids\" contains more values than allowed. Max value is " + MAX_USER_IDS);
+    }
+  }
+
+  private Map<String, String> buildAUIActionAttributes() {
+    Map<String, String> presentationAttrs = new LinkedHashMap<>();
+
+    presentationAttrs.put(CLASS_ATTR, MESSAGEML_TAG);
+    presentationAttrs.put(PRESENTATIONML_ACTION_ATTR, getAttribute(ACTION_ATTR));
+
+    if (getAttribute(TRIGGER_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_TRIGGER_ATTR, getAttribute(TRIGGER_ATTR));
+    }
+    if (getAttribute(USER_IDS_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_USER_IDS_ATTR, getAttribute(USER_IDS_ATTR));
+    }
+    if (getAttribute(STREAM_ID_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_STREAM_ID_ATTR, getAttribute(STREAM_ID_ATTR));
+    }
+    if (getAttribute(SIDE_BY_SIDE_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_SIDE_BY_SIDE_ATTR, getAttribute(SIDE_BY_SIDE_ATTR));
+    }
+
+    return presentationAttrs;
+  }
+
+
+}

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/UIAction.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/UIAction.java
@@ -1,13 +1,11 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -52,8 +50,6 @@ public class UIAction extends Element {
   private static final String PRESENTATIONML_STREAM_ID_ATTR = "data-stream-id";
   private static final String PRESENTATIONML_SIDE_BY_SIDE_ATTR = "data-side-by-side";
 
-
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   public UIAction(Element parent, FormatEnum format) {
     super(parent, MESSAGEML_TAG, format);
@@ -102,7 +98,9 @@ public class UIAction extends Element {
     if (getAttribute(USER_IDS_ATTR) == null && getAttribute(STREAM_ID_ATTR) == null) {
       throw new InvalidInputException("At least one between \"stream-id\" and \"user-ids\" should be present");
     }
-    validateUserIdsAttribute();
+    if (getAttribute(USER_IDS_ATTR) != null) {
+      validateUserIdsAttribute();
+    }
   }
 
   private void assertUIActionAllowedChildren() throws InvalidInputException {
@@ -128,16 +126,13 @@ public class UIAction extends Element {
 
   private void validateUserIdsAttribute() throws InvalidInputException {
     String userIds = getAttribute(USER_IDS_ATTR);
-    List<Long> userIdsList = new ArrayList<>();
-    if (userIds != null) {
-      try {
-        userIdsList = MAPPER.readValue(userIds, MAPPER.getTypeFactory().constructCollectionType(List.class, Long.class));
-      } catch (JsonProcessingException e) {
-        throw new InvalidInputException("Attribute \"user-ids\" contains an unsupported format, should be an array of user ids");
+    try {
+      List<Long> userIdsList = MAPPER.readValue(userIds, MAPPER.getTypeFactory().constructCollectionType(List.class, Long.class));
+      if(userIdsList.size() > MAX_USER_IDS){
+        throw new InvalidInputException("Attribute \"user-ids\" contains more values than allowed. Max value is " + MAX_USER_IDS);
       }
-    }
-    if(userIdsList.size() > MAX_USER_IDS){
-      throw new InvalidInputException("Attribute \"user-ids\" contains more values than allowed. Max value is " + MAX_USER_IDS);
+    } catch (JsonProcessingException e) {
+      throw new InvalidInputException("Attribute \"user-ids\" contains an unsupported format, should be an array of user ids");
     }
   }
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/UIActionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/UIActionTest.java
@@ -1,0 +1,298 @@
+package org.symphonyoss.symphony.messageml.elements;
+
+import org.junit.Test;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class UIActionTest extends ElementTest {
+
+  @Test
+  public void testUIActionWithInvalidAction() throws InvalidInputException, IOException, ProcessingException {
+    String inputMessageML =
+            "<messageML><ui-action action=\"open\">" +
+              "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"action\" of element \"ui-action\" can only be one of the " +
+            "following values: [open-im].");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testUIActionWhenActionNotFound() throws InvalidInputException, IOException, ProcessingException {
+    String inputMessageML =
+            "<messageML><ui-action>" +
+              "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The attribute \"action\" is required");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testUIActionWithTrigger() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123]\">" +
+              "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    String expectedPresentationML =
+            "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
+              "<div class=\"ui-action\" data-action=\"open-im\" data-trigger=\"click\" data-user-ids=\"[123]\">" +
+                "<button>Open by stream ID</button>" +
+            "</div></div>";
+
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+
+    validateMessageMLSimpleStructure();
+    assertPresentationML(expectedPresentationML);
+  }
+
+  @Test
+  public void testUIActionWithDefaultTrigger() throws InvalidInputException, IOException, ProcessingException {
+    String inputMessageML =
+            "<messageML><ui-action action=\"open-im\" user-ids=\"[123]\">" +
+              "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+    String expectedPresentationML =
+            "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
+              "<div class=\"ui-action\" data-action=\"open-im\" data-trigger=\"click\" data-user-ids=\"[123]\">" +
+                "<button>Open by stream ID</button>" +
+            "</div></div>";
+
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+
+    validateMessageMLSimpleStructure();
+    assertPresentationML(expectedPresentationML);
+  }
+
+  @Test
+  public void testUIActionWithInvalidTrigger() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action trigger=\"double click\" action=\"open-im\" user-ids=\"[123]\">" +
+              "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"trigger\" of element \"ui-action\" can only be one of the " +
+            "following values: [click].");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testUIActionUsingUserIdsList() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,456]\">" +
+              "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    String expectedPresentationML =
+            "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
+              "<div class=\"ui-action\" data-action=\"open-im\" data-trigger=\"click\" data-user-ids=\"[123,456]\">" +
+                "<button>Open by stream ID</button>" +
+            "</div></div>";
+
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+
+    validateMessageMLSimpleStructure();
+    assertPresentationML(expectedPresentationML);
+  }
+
+  @Test
+  public void testUIActionUsingMoreThanAllowedUserIds() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action action=\"open-im\" user-ids=\"[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]\">" +
+              "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"user-ids\" contains more values than allowed. Max value is 15");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testUIActionInvalidUserIds() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,abc]\">" +
+              "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"user-ids\" contains an unsupported format, " +
+            "should be an array of user ids");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testUIActionUsingStreamId() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action trigger=\"click\" action=\"open-im\" stream-id=\"UUzhhBMMC+PTHBj0SuoQrn///onSQszYdA==\">" +
+              "<button title=\"this is a hint\">Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    String expectedPresentationML =
+            "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
+              "<div class=\"ui-action\" data-action=\"open-im\" data-trigger=\"click\" " +
+                    "data-stream-id=\"UUzhhBMMC+PTHBj0SuoQrn///onSQszYdA==\">" +
+                "<button data-title=\"this is a hint\">Open by stream ID</button>" +
+            "</div></div>";
+
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+
+    validateMessageMLSimpleStructure();
+    assertPresentationML(expectedPresentationML);
+  }
+
+  @Test
+  public void testUIActionUsingUserIdsAndStreamId() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,456]\" " +
+                    "stream-id=\"UUzhhBMMC+PTHBj0SuoQrn///onSQszYdA==\">" +
+                "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Only one between \"stream-id\" and \"user-ids\" is allowed");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testUIActionUsingNoUserIdsOrStreamId() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action trigger=\"click\" action=\"open-im\">" +
+              "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("At least one between \"stream-id\" and \"user-ids\" should be present");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testUIActionUsingSideBySide() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,456]\" side-by-side=\"true\">" +
+              "<button class=\"primary\" title=\"This is a hint\">Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    String expectedPresentationML =
+            "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
+              "<div class=\"ui-action\" data-action=\"open-im\" data-trigger=\"click\" data-user-ids=\"[123,456]\" " +
+                    "data-side-by-side=\"true\">" +
+                "<button class=\"primary\" data-title=\"This is a hint\">Open by stream ID</button>" +
+            "</div></div>";
+
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+
+    validateMessageMLSimpleStructure();
+    assertPresentationML(expectedPresentationML);
+  }
+
+  @Test
+  public void testUIActionUsingInvalidSideBySide() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,456]\" side-by-side=\"hello\">" +
+              "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"side-by-side\" of element \"ui-action\" can only be one " +
+            "of the following values: [true, false].");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testUIActionWithoutButtonChild() throws Exception {
+    String inputMessageML =
+            "<messageML>" +
+              "<ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,456]\" side-by-side=\"true\"></ui-action>" +
+            "</messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The \"ui-action\" element must have at least one child that is any of " +
+            "the following elements: [button, uiaction].");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testUIActionDivChild() throws Exception {
+    String inputMessageML =
+            "<messageML><ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,456]\" side-by-side=\"true\">" +
+              "<div>This is a div</div>" +
+            "</ui-action></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Element \"div\" is not allowed in \"ui-action\"");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testNestedUIAction() throws Exception {
+    String inputMessageML =
+            "<messageML>" +
+              "<ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,456]\">" +
+                "<ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,456]\">" +
+                  "<button class=\"secondary\">Open by stream ID</button>" +
+                "</ui-action>" +
+              "</ui-action>" +
+            "</messageML>";
+
+    String expectedPresentationML =
+            "<div data-format=\"PresentationML\" data-version=\"2.0\">" +
+              "<div class=\"ui-action\" data-action=\"open-im\" data-trigger=\"click\" data-user-ids=\"[123,456]\">" +
+                "<div class=\"ui-action\" data-action=\"open-im\" data-trigger=\"click\" data-user-ids=\"[123,456]\">" +
+                  "<button class=\"secondary\">Open by stream ID</button>" +
+                "</div>" +
+              "</div>" +
+            "</div>";
+
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    Element uiAction1 = messageML.getChildren().get(0);
+    Element uiAction2 = uiAction1.getChildren().get(0);
+    Element simpleButton = uiAction2.getChildren().get(0);
+
+    assertEquals(UIAction.class, uiAction1.getClass());
+    assertEquals(UIAction.class, uiAction2.getClass());
+    assertEquals(Button.class, simpleButton.getClass());
+    assertPresentationML(expectedPresentationML);
+  }
+
+  @Test
+  public void testNestedUIActionWithoutNestedButton() throws Exception {
+    String inputMessageML =
+            "<messageML>" +
+              "<ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,456]\">" +
+                "<ui-action trigger=\"click\" action=\"open-im\" user-ids=\"[123,456]\">" +
+                "</ui-action>" +
+              "</ui-action>" +
+            "</messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("The \"ui-action\" element must have at least one child that is any of " +
+            "the following elements: [button, uiaction].");
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+
+  }
+
+  private void validateMessageMLSimpleStructure() {
+    Element messageML = context.getMessageML();
+    Element uiAction = messageML.getChildren().get(0);
+    Element simpleButton = uiAction.getChildren().get(0);
+
+    assertEquals(UIAction.class, uiAction.getClass());
+    assertEquals(Button.class, simpleButton.getClass());
+  }
+
+  private void assertPresentationML(String expectedPresentationML) {
+    String presentationML = context.getPresentationML();
+    assertEquals(expectedPresentationML, presentationML);
+  }
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
@@ -1,6 +1,8 @@
 package org.symphonyoss.symphony.messageml.elements.form;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.symphonyoss.symphony.messageml.elements.Button.ACTION_TYPE;
 import static org.symphonyoss.symphony.messageml.elements.Button.RESET_TYPE;
@@ -26,7 +28,7 @@ public class ButtonTest extends ElementTest {
   private static final String FORM_ID_ATTR = "text-field-form";
 
   @Test
-  public void testCompleteButton() throws Exception {
+  public void testCompleteButtonInForm() throws Exception {
     String type = ACTION_TYPE;
     String name = "action-btn-name";
     String clazz = "primary";
@@ -61,9 +63,8 @@ public class ButtonTest extends ElementTest {
 
   @Test
   public void testSendingResetButtonWithoutActionButton() {
-    String type = RESET_TYPE;
     String innerText = "Reset";
-    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + type + "\">" + innerText +
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + RESET_TYPE + "\">" + innerText +
         "</button></form></messageML>";
     try {
       context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
@@ -147,7 +148,7 @@ public class ButtonTest extends ElementTest {
   }
 
   @Test
-  public void testTypelessButtonWithoutName() throws Exception {
+  public void testTypelessButtonWithoutName() {
     String innerText = "Typeless Button Without Name";
     String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button>" + innerText + "</button></form></messageML>";
 
@@ -161,10 +162,9 @@ public class ButtonTest extends ElementTest {
   }
 
   @Test
-  public void testActionButtonWithoutName() throws Exception {
-    String type = ACTION_TYPE;
+  public void testActionButtonWithoutName() {
     String innerText = "Typeless Button Without Name";
-    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + type + "\">" + innerText + "</button></form></messageML>";
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + ACTION_TYPE + "\">" + innerText + "</button></form></messageML>";
 
     try {
       context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
@@ -176,10 +176,9 @@ public class ButtonTest extends ElementTest {
   }
 
   @Test
-  public void testActionButtonWithBlankName() throws Exception {
-    String type = ACTION_TYPE;
+  public void testActionButtonWithBlankName() {
     String innerText = "Typeless Button Without Name";
-    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + type + "\" name=\" \">" + innerText + "</button></form></messageML>";
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + ACTION_TYPE + "\" name=\" \">" + innerText + "</button></form></messageML>";
 
     try {
       context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
@@ -191,10 +190,9 @@ public class ButtonTest extends ElementTest {
   }
 
   @Test
-  public void testResetButtonWithName() throws Exception {
-    String type = RESET_TYPE;
+  public void testResetButtonWithName() {
     String innerText = "Reset";
-    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + type + "\" name=\" \">" + innerText + "</button></form></messageML>";
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + RESET_TYPE + "\" name=\" \">" + innerText + "</button></form></messageML>";
 
     try {
       context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
@@ -207,9 +205,8 @@ public class ButtonTest extends ElementTest {
 
   @Test
   public void testActionButtonWithoutTextNode() throws Exception {
-    String type = ACTION_TYPE;
     String name = "btn-name";
-    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + type + "\" name=\"" + name + "\"></button></form></messageML>";
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + ACTION_TYPE + "\" name=\"" + name + "\"></button></form></messageML>";
 
     expectedException.expect(InvalidInputException.class);
     expectedException.expectMessage("The \"button\" element must have at least one child that is any of the following elements: [text content].");
@@ -218,22 +215,21 @@ public class ButtonTest extends ElementTest {
   }
 
   @Test
-  public void testMisplacedButton() throws Exception {
+  public void testMisplacedButton() {
     String innerText = "Misplaced Button";
-    String type = RESET_TYPE;
-    String input = "<messageML><button type=\"" + type + "\">" + innerText + "</button></messageML>";
+    String input = "<messageML><button type=\"" + RESET_TYPE + "\">" + innerText + "</button></messageML>";
 
     try {
       context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
       fail("Should have thrown an exception on button out of a form tag");
     } catch (Exception e) {
       assertEquals("Exception class", InvalidInputException.class, e.getClass());
-      assertEquals("Exception message", "Element \"button\" can only be a inner child of the following elements: [form]", e.getMessage());
+      assertEquals("Exception message", "Element \"button\" can only be a inner child of the following elements: [form, uiaction]", e.getMessage());
     }
   }
 
   @Test
-  public void testBadTypeButton() throws Exception {
+  public void testBadTypeButton() {
     String innerText = "Invalid Type Button";
     String type = "potato";
     String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + type + "\">" + innerText + "</button></form></messageML>";
@@ -248,11 +244,10 @@ public class ButtonTest extends ElementTest {
   }
 
   @Test
-  public void testBadClassButton() throws Exception {
+  public void testBadClassButton() {
     String innerText = "Invalid Class Button";
-    String type = RESET_TYPE;
     String clazz = "outclassed";
-    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + type + "\" class=\"" + clazz + "\">" + innerText
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + RESET_TYPE + "\" class=\"" + clazz + "\">" + innerText
             + "</button></form></messageML>";
 
     try {
@@ -267,11 +262,10 @@ public class ButtonTest extends ElementTest {
   }
 
   @Test
-  public void testBadAttributeButton() throws Exception {
+  public void testBadAttributeButton() {
     String innerText = "Invalid Attribute Button";
-    String type = RESET_TYPE;
     String invalidAttribute = "invalid-attribute";
-    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + type + "\" " + invalidAttribute + "=\"invalid\">" + innerText
+    String input = "<messageML><form id=\"" + FORM_ID_ATTR + "\"><button type=\"" + RESET_TYPE + "\" " + invalidAttribute + "=\"invalid\">" + innerText
             + "</button></form></messageML>";
 
     try {
@@ -297,12 +291,54 @@ public class ButtonTest extends ElementTest {
     
     assertEquals("Button name attribute", "div-button", button.getAttribute(NAME_ATTR));
     assertEquals("Button type attribute", "action", button.getAttribute(TYPE_ATTR));
-    assertEquals("Button clazz attribute", null, button.getAttribute(CLASS_ATTR));
+    assertNull("Button clazz attribute", button.getAttribute(CLASS_ATTR));
     assertEquals("Button inner text", "SELECT", button.getChild(0).asText());
 
     assertEquals("Button markdown", "Form (log into desktop client to answer):\n---\n(Button:SELECT)\n\n\n---\n", context.getMarkdown());
     assertEquals("Button presentationML", "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"example\"><div><button type=\"action\" name=\"div-button\">SELECT</button></div></form></div>",
         context.getPresentationML());
+  }
+
+  @Test
+  public void testButtonInUIAction() throws Exception {
+    String input = "<messageML><ui-action action=\"open-im\" user-ids=\"[123]\">" +
+            "<button>Open by stream ID</button>" +
+            "</ui-action></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    Element uiAction = messageML.getChildren().get(0);
+    Element button = uiAction.getChildren().get(0);
+
+    assertEquals("Button class", Button.class, button.getClass());
+    assertTrue(button.getAttributes().isEmpty());
+  }
+
+  @Test
+  public void testButtonWithAttributesInUIAction() throws Exception {
+    String input = "<messageML><ui-action action=\"open-im\" user-ids=\"[123]\">" +
+            "<button class=\"primary\" title=\"This is a UIAction button\">Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    Element uiAction = messageML.getChildren().get(0);
+    Element button = uiAction.getChildren().get(0);
+
+    assertEquals("Button class", Button.class, button.getClass());
+    assertEquals(2, button.getAttributes().size());
+  }
+
+  @Test
+  public void testButtonWithInvalidAttributesInUIAction() throws Exception {
+    String input = "<messageML><ui-action action=\"open-im\" user-ids=\"[123]\">" +
+            "<button type=\"reset\">Open by stream ID</button>" +
+            "</ui-action></messageML>";
+
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attributes \"type\" and \"name\" are not allowed on a button inside a UIAction.");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
 
   private String getNamePresentationML(String name) {


### PR DESCRIPTION
Closes https://github.com/symphonyoss/messageml-utils/issues/261

Adding new messageML tag UIAction which is represented by the tag name "ui-action".
The messageML representation of this element can contain the following fields:
- trigger  -> default 'click', trigger of the action. For now only 'click' is supported
- action (required) -> action that can be executed on trigger. For now only 'open-im' is supported
- user-ids (exclusive with stream-id)-> list of the users we want the action to be applied on
- stream-id (exclusive with user-ids) -> stream we want the action to be applied on
- side-by-side -> default true, open the result chat in a new module and keeps the parent one open side by side. If false, the parent one will be replaced.
For now only Buttons and other UIActions will be allowed as child of a ui-action.