### PR TITLE
Remove direct usage of Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,7 @@
     </contributors>
 
     <properties>
-        <json.schema.validator.version>2.2.10</json.schema.validator.version>
-        <guava.version>28.0-jre</guava.version>
+        <json.schema.validator.version>2.2.14</json.schema.validator.version>
         <jackson.version>2.10.1</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <commons.io.version>2.7</commons.io.version>
@@ -243,20 +242,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>${json.schema.validator.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Styles.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Styles.java
@@ -1,6 +1,5 @@
 package org.symphonyoss.symphony.messageml.elements;
 
-import com.google.common.base.Joiner;
 import org.apache.commons.lang3.StringUtils;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 
@@ -156,7 +155,7 @@ public class Styles {
           .collect(Collectors.toSet());
       inputStyleProperties.removeAll(ALLOWED_PROPERTIES);
       if (!inputStyleProperties.isEmpty()) {
-        throw new InvalidInputException("Invalid property(s): [" + Joiner.on(",").join(inputStyleProperties) + "] in the \"style\" attribute");
+        throw new InvalidInputException("Invalid property(s): " + inputStyleProperties + " in the \"style\" attribute");
       }
     } catch (IllegalArgumentException ex) {
       throw new InvalidInputException("Unparseable \"style\" attribute: " + styleAttribute, ex);

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/StylesTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/StylesTest.java
@@ -15,8 +15,8 @@ public class StylesTest extends ElementTest {
   @Test
   public void validateInvalidPropertyValidProperty() throws Exception {
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("Invalid property(s): [back] in the \"style\" attribute");
-    Styles.validate("back:c;background:values values values;background-attachment:values");
+    expectedException.expectMessage("Invalid property(s): [back, back2] in the \"style\" attribute");
+    Styles.validate("back:c;back2:c;background:values values values;background-attachment:values");
   }
 
   @Test


### PR DESCRIPTION
Looks like it is not really needed, so avoid a direct dependency on it
(it is still used as transitive dependency by json schema validator)