### PR TITLE
MML-268 BI: Fill BiContext with Symphony Elements BI items and associated properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <freemarker.version>2.3.30</freemarker.version>
         <commonmark.version>0.15.1</commonmark.version>
         <junit.version>4.13.1</junit.version>
+        <junit.jupiter.params.version>5.7.1</junit.jupiter.params.version>
         <mockito.version>1.9.5</mockito.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -297,6 +298,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.params.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiContext.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiContext.java
@@ -1,10 +1,12 @@
 package org.symphonyoss.symphony.messageml.bi;
 
+import joptsimple.internal.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -60,8 +62,32 @@ public class BiContext {
     }
   }
 
+  public void updateItem(String itemName, Map<String, Object> attributes) {
+    Optional<BiItem> optionalBiItem = getItemWithName(itemName);
+    if (optionalBiItem.isPresent()) {
+      attributes.forEach((key, value) -> {
+        if (!value.equals(Strings.EMPTY) && optionalBiItem.get().getAttributes().get(key) != null) {
+          optionalBiItem.get().increaseAttributeCount(key);
+        } else if (optionalBiItem.get().getAttributes().get(key) == null) {
+          optionalBiItem.get().getAttributes().put(key, value);
+        }
+      });
+    } else {
+      addItem(new BiItem(itemName, attributes));
+    }
+  }
+
   private Optional<BiItem> getItemWithName(String itemName) {
     return getItems().stream().filter(item -> item.getName().equals(itemName)).findFirst();
+  }
+
+  public boolean isAttributeSet(String itemName, String attributeName) {
+    Optional<BiItem> optionalBiTem = getItemWithName(itemName);
+    if (optionalBiTem.isPresent() && optionalBiTem.get().getAttributes() != null
+        && optionalBiTem.get().getAttributes().get(attributeName) != null) {
+      return true;
+    }
+    return false;
   }
 
   private static String extractVersion() {

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiContext.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiContext.java
@@ -1,6 +1,6 @@
 package org.symphonyoss.symphony.messageml.bi;
 
-import joptsimple.internal.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,11 +66,10 @@ public class BiContext {
     Optional<BiItem> optionalBiItem = getItemWithName(itemName);
     if (optionalBiItem.isPresent()) {
       attributes.forEach((key, value) -> {
-        if (!value.equals(Strings.EMPTY) && optionalBiItem.get().getAttributes().get(key) != null) {
+        if (!StringUtils.isEmpty(String.valueOf(value))
+            && optionalBiItem.get().getAttributes().get(key) != null) {
           optionalBiItem.get().increaseAttributeCount(key);
-        } else if (optionalBiItem.get().getAttributes().get(key) == null) {
-          optionalBiItem.get().getAttributes().put(key, value);
-        }
+        } else { optionalBiItem.get().getAttributes().putIfAbsent(key, value); }
       });
     } else {
       addItem(new BiItem(itemName, attributes));
@@ -83,11 +82,8 @@ public class BiContext {
 
   public boolean isAttributeSet(String itemName, String attributeName) {
     Optional<BiItem> optionalBiTem = getItemWithName(itemName);
-    if (optionalBiTem.isPresent() && optionalBiTem.get().getAttributes() != null
-        && optionalBiTem.get().getAttributes().get(attributeName) != null) {
-      return true;
-    }
-    return false;
+    return optionalBiTem.isPresent() && optionalBiTem.get().getAttributes() != null
+        && optionalBiTem.get().getAttributes().get(attributeName) != null;
   }
 
   private static String extractVersion() {

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
@@ -1,5 +1,7 @@
 package org.symphonyoss.symphony.messageml.bi;
 
+import joptsimple.internal.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,11 +63,20 @@ public class BiItem {
    */
   protected void increaseAttributeCount(String attributeName) {
     try {
-      Integer value = (Integer) attributes.getOrDefault(attributeName, 0) + 1;
+      Integer value = getZeroIfEmptyString(attributeName);
+      value ++;
       attributes.put(attributeName, value);
     } catch (ClassCastException e) {
       logger.warn("Attribute {} for element {} does not contain an integer value. The count will not be increased.",
               attributeName, getName());
     }
+  }
+
+  private Integer getZeroIfEmptyString(String attributeName) {
+    Object value = attributes.getOrDefault(attributeName, 0);
+    if (value.equals(StringUtils.EMPTY)) {
+      return 0;
+    }
+    return (Integer) value;
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiItem.java
@@ -1,6 +1,5 @@
 package org.symphonyoss.symphony.messageml.bi;
 
-import joptsimple.internal.Strings;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +73,7 @@ public class BiItem {
 
   private Integer getZeroIfEmptyString(String attributeName) {
     Object value = attributes.getOrDefault(attributeName, 0);
-    if (value.equals(StringUtils.EMPTY)) {
+    if (StringUtils.isEmpty(String.valueOf(value))) {
       return 0;
     }
     return (Integer) value;

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -9,6 +9,7 @@ import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.ButtonNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 import org.w3c.dom.Node;
 
@@ -161,9 +162,10 @@ public class Button extends Element {
   @Override
   public void updateBiContext(BiContext context) {
     Map<String, Object> attributesMapBi = new HashMap<>();
-    attributesMapBi.put(TYPE_ATTR, getAttributes().getOrDefault(TYPE_ATTR, ""));
-    attributesMapBi.put(CLASS_ATTR, getAttributes().getOrDefault(CLASS_ATTR, ""));
-    attributesMapBi.put(TooltipableElement.TITLE, getAttributes().containsKey(TooltipableElement.TITLE) ? 1 : StringUtils.EMPTY);
-    context.addItem(new BiItem("Button", attributesMapBi));
+
+    this.putStringIfPresent(attributesMapBi, BiFields.STYLE_COLOR.getFieldName(), CLASS_ATTR);
+    this.putStringIfPresent(attributesMapBi, BiFields.TYPE.getFieldName(), TYPE_ATTR);
+
+    context.addItem(new BiItem(BiFields.BUTTON.getFieldName(), attributesMapBi));
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Checkbox.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Checkbox.java
@@ -2,18 +2,21 @@ package org.symphonyoss.symphony.messageml.elements;
 
 import org.commonmark.node.Node;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.CheckboxNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
 import java.util.Arrays;
-import java.util.Optional;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Class representing a Checkbox inside a Form.
  * @author Cristiano Faustino
  * @since 05/29/2019
  */
-public class Checkbox extends GroupedElement implements LabelableElement{
+public class Checkbox extends GroupedElement implements LabelableElement {
   public static final String MESSAGEML_TAG = "checkbox";
   public static final String PRESENTATIONML_INPUT_TYPE = "checkbox";
   public static final String PRESENTATIONML_DIV_CLASS = "checkbox-group";
@@ -71,6 +74,38 @@ public class Checkbox extends GroupedElement implements LabelableElement{
     }
     else {
       return new CheckboxNode();
+    }
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    attributesMapBi.put(BiFields.OPTIONS_COUNT.getFieldName(), 1);
+    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getFieldName(), LABEL);
+    this.computeAndPutDefault(context, attributesMapBi);
+
+    context.updateItem(BiFields.CHECKBOX.getFieldName(), attributesMapBi);
+  }
+
+  /**
+   * This method will compute default property for this element : if {@link
+   * GroupedElement#CHECKED_ATTR attribute is set to true}
+   * It will update the context if and only if this current option is the first option
+   * of the checkboxes group to have default value set to true
+   *
+   * If {@link GroupedElement#CHECKED_ATTR} attribute is not explicitly set to true,
+   * this default property will be considered as not set like in following :
+   * <pre><checkbox checked=\"false\">Check Me if you can!</checkbox></pre>
+   * <pre><checkbox checked=\"somethingElse\">Check Me if you can!</checkbox></pre>
+   */
+  private void computeAndPutDefault(BiContext context, Map<String, Object> attributesMapBi) {
+    String isChecked = getAttribute(CHECKED_ATTR);
+    boolean isDefaultAlreadySet =
+        context.isAttributeSet(BiFields.CHECKBOX.getFieldName(), BiFields.DEFAULT.getFieldName());
+
+    if (isChecked != null && Boolean.TRUE.equals(Boolean.valueOf(isChecked)) && !isDefaultAlreadySet) {
+      attributesMapBi.put(BiFields.DEFAULT.getFieldName(), 1);
     }
   }
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
@@ -3,8 +3,11 @@ package org.symphonyoss.symphony.messageml.elements;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.DatePickerNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.symphonyoss.symphony.messageml.util.XMLAttribute;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 import org.symphonyoss.symphony.messageml.util.pojo.DateInterval;
@@ -12,6 +15,7 @@ import org.w3c.dom.Node;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -138,6 +142,61 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
       out.closeElement();
     } else {
       innerAsPresentationML(out, presentationAttrs);
+    }
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    this.putOneIfPresent(attributesMapBi, BiFields.TITLE.getFieldName(), TITLE);
+    this.putOneIfPresent(attributesMapBi, BiFields.PLACEHOLDER.getFieldName(), PLACEHOLDER_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getFieldName(), LABEL);
+    this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getFieldName(), REQUIRED_ATTR);
+    this.computeAndPutDefault(attributesMapBi);
+    this.computeAndPutValidationProperties(attributesMapBi);
+
+    context.addItem(new BiItem(BiFields.DATE_SELECTOR.getFieldName(), attributesMapBi));
+  }
+
+  private void computeAndPutDefault(Map<String, Object> attributesMapBi) {
+    boolean hasDefaultValue = getAttribute(VALUE_ATTR) != null;
+    if (hasDefaultValue) {
+      attributesMapBi.put(BiFields.DEFAULT.getFieldName(), 1);
+    }
+  }
+
+  private void computeAndPutValidationProperties(Map<String, Object> attributesMapBi) {
+    boolean validationMin = getAttribute(MIN_ATTR) != null;
+    boolean validationMax = getAttribute(MAX_ATTR) != null;
+    boolean validationPattern = getAttribute(FORMAT_ATTR) != null;
+    boolean validationOptions = getAttribute(DISABLED_DATE_ATTR) != null;
+    boolean highlightedOptions = getAttribute(HIGHLIGHTED_DATE_ATTR) != null;
+    boolean hasValidation =
+        validationMin || validationMax || validationPattern || validationOptions;
+
+    if (validationMin) {
+      attributesMapBi.put(BiFields.VALIDATION_MIN.getFieldName(), 1);
+    }
+
+    if (validationMax) {
+      attributesMapBi.put(BiFields.VALIDATION_MAX.getFieldName(), 1);
+    }
+
+    if (validationPattern) {
+      attributesMapBi.put(BiFields.VALIDATION_PATTERN.getFieldName(), 1);
+    }
+
+    if (validationOptions) {
+      attributesMapBi.put(BiFields.VALIDATION_OPTIONS.getFieldName(), 1);
+    }
+
+    if (highlightedOptions) {
+      attributesMapBi.put(BiFields.HIGHLIGHTED_OPTIONS.getFieldName(), 1);
+    }
+
+    if (hasValidation) {
+      attributesMapBi.put(BiFields.VALIDATION.getFieldName(), 1);
     }
   }
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DateSelector.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DateSelector.java
@@ -3,18 +3,19 @@ package org.symphonyoss.symphony.messageml.elements;
 import org.commonmark.node.Node;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.DateSelectorNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.NodeList;
 
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Class representing a date-selector element inside a Symphony Elements form.
@@ -58,9 +59,9 @@ public class DateSelector extends FormElement {
   @Override
   public void validate() throws InvalidInputException {
     super.validate();
-    
+
     assertAttributeNotBlank(NAME_ATTR);
-    
+
     if(getAttribute(REQUIRED_ATTR) != null) {
       assertAttributeIsBoolean(REQUIRED_ATTR);
     }
@@ -119,6 +120,18 @@ public class DateSelector extends FormElement {
     }
 
     return presentationAttrs;
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    this.putOneIfPresent(attributesMapBi, BiFields.PLACEHOLDER.getFieldName(), PLACEHOLDER_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getFieldName(), REQUIRED_ATTR);
+    // no default values to check
+    // no validations to check
+
+    context.addItem(new BiItem(BiFields.DATE_SELECTOR.getFieldName(), attributesMapBi));
   }
 
   void buildElementFromDiv(MessageMLParser parser, org.w3c.dom.Element element) throws InvalidInputException, ProcessingException {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Entity.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Entity.java
@@ -21,8 +21,13 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.w3c.dom.Node;
+
+import java.util.Collections;
 
 /**
  * @author lukasz
@@ -93,6 +98,13 @@ public abstract class Entity extends Element {
     if (this.format == FormatEnum.PRESENTATIONML && this.entityId == null) {
       throw new InvalidInputException("The attribute \"data-entity-id\" is required");
     }
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    super.updateBiContext(context);
+    context.addItem(new BiItem(BiFields.ENTITY.getFieldName(),
+        Collections.singletonMap(BiFields.ENTITY_TYPE.getFieldName(), this.getEntitySubType())));
   }
 
   String getEntityId(int index) {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
@@ -1,12 +1,16 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.OptionNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.w3c.dom.Node;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Class representing a Symphony Elements option
@@ -41,6 +45,16 @@ public class Option extends FormElement {
     assertParent(Collections.singleton(Select.class));
     assertContentModel(Collections.singleton(TextNode.class));
     assertContainsChildOfType(Collections.singleton(TextNode.class));
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    attributesMapBi.put(BiFields.OPTIONS_COUNT.getFieldName(), 1);
+    this.putOneIfPresent(attributesMapBi, BiFields.DEFAULT.getFieldName(), SELECTED_ATTR);
+
+    context.updateItem(BiFields.OPTION.getFieldName(), attributesMapBi);
   }
 
   @Override

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/PersonSelector.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/PersonSelector.java
@@ -5,14 +5,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.commonmark.node.Node;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.PersonSelectorNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.NodeList;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -201,6 +205,18 @@ public class PersonSelector extends FormElement implements LabelableElement, Too
   @Override
   public String getElementId() {
     return MESSAGEML_TAG;
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    this.putOneIfPresent(attributesMapBi, BiFields.TITLE.getFieldName(), TITLE);
+    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getFieldName(), LABEL);
+    this.putOneIfPresent(attributesMapBi, BiFields.PLACEHOLDER.getFieldName(), PLACEHOLDER_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getFieldName(), REQUIRED_ATTR);
+    
+    context.addItem(new BiItem(BiFields.PERSON_SELECTOR.getFieldName(), attributesMapBi));
   }
 
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Radio.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Radio.java
@@ -17,12 +17,15 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.RadioNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.w3c.dom.Node;
 
 import java.util.Arrays;
-import java.util.Optional;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Class representing Radio Buttons - Symphony Elements.
@@ -30,7 +33,7 @@ import java.util.Optional;
  * @author Pedro Sanchez
  * @since 06/13/19
  */
-public class Radio extends GroupedElement implements LabelableElement{
+public class Radio extends GroupedElement implements LabelableElement {
 
   public static final String MESSAGEML_TAG = "radio";
 
@@ -104,4 +107,36 @@ public class Radio extends GroupedElement implements LabelableElement{
   public String getElementId() {
     return MESSAGEML_TAG;
   }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    attributesMapBi.put(BiFields.OPTIONS_COUNT.getFieldName(), 1);
+    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getFieldName(), LABEL);
+    this.computeAndPutDefault(context, attributesMapBi);
+
+    context.updateItem(BiFields.RADIO.getFieldName(), attributesMapBi);
+  }
+
+  /**
+   * This method will compute default property for this element : if {@link
+   * GroupedElement#CHECKED_ATTR attribute is set to true}
+   * It will update the context if and only if this current option is the first option
+   * of the radio group to have default value set to true
+   *
+   * If {@link GroupedElement#CHECKED_ATTR} attribute is not explicitly set to true,
+   * this default property will be considered as not set like in following :
+   * <pre><radio checked=\"false\">Check Me if you can!</radio></pre>
+   * <pre><radio checked=\"somethingElse\">Check Me if you can!</radio></pre>
+   */
+  private void computeAndPutDefault(BiContext context, Map<String, Object> attributesMapBi) {
+    String isChecked = getAttribute(CHECKED_ATTR);
+    boolean isDefaultAlreadySet =
+        context.isAttributeSet(BiFields.RADIO.getFieldName(), BiFields.DEFAULT.getFieldName());
+    if (isChecked != null && Boolean.TRUE.equals(Boolean.valueOf(isChecked)) && !isDefaultAlreadySet) {
+      attributesMapBi.put(BiFields.DEFAULT.getFieldName(), 1);
+    }
+  }
+
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
@@ -17,13 +17,17 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.SelectNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.w3c.dom.Node;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Class representing dropdown menu - Symphony Elements.
@@ -87,6 +91,18 @@ public class Select extends FormElement implements LabelableElement, Tooltipable
       default:
         throwInvalidInputException(item);
     }
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    this.putOneIfPresent(attributesMapBi, BiFields.TITLE.getFieldName(), TITLE);
+    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getFieldName(), LABEL);
+    this.putOneIfPresent(attributesMapBi, BiFields.PLACEHOLDER.getFieldName(), DATA_PLACEHOLDER_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getFieldName(), REQUIRED_ATTR);
+
+    context.addItem(new BiItem(BiFields.SELECT.getFieldName(), attributesMapBi));
   }
 
   @Override

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TextArea.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TextArea.java
@@ -2,19 +2,24 @@ package org.symphonyoss.symphony.messageml.elements;
 
 import org.commonmark.node.Node;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.TextAreaNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Class representing a Text Area inside a Form.
  * @author Sandro Ribeiro
  * @since 06/12/2019
  */
-public class TextArea extends FormElement implements RegexElement, LabelableElement, TooltipableElement, MinMaxLengthElement{
+public class TextArea extends FormElement implements RegexElement, LabelableElement, TooltipableElement, MinMaxLengthElement {
 
   public static final String MESSAGEML_TAG = "textarea";
 
@@ -123,5 +128,31 @@ public class TextArea extends FormElement implements RegexElement, LabelableElem
   @Override
   public Integer getMaxValueAllowed() {
     return MAX_ALLOWED_LENGTH;
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    this.putOneIfPresent(attributesMapBi, BiFields.PLACEHOLDER.getFieldName(), PLACEHOLDER_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.TITLE.getFieldName(), TITLE);
+    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getFieldName(), LABEL);
+    this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getFieldName(), REQUIRED_ATTR);
+    this.computeAndPutValidationProperties(attributesMapBi);
+
+    if (this.hasElementInitialValue()) {
+      attributesMapBi.put(BiFields.DEFAULT.getFieldName(), 1);
+    }
+
+    context.addItem(new BiItem(BiFields.TEXT_AREA.getFieldName(), attributesMapBi));
+  }
+
+  private void computeAndPutValidationProperties(Map<String, Object> attributesMapBi) {
+    boolean validationPattern = getAttribute(PATTERN_ATTR) != null;
+
+    if (validationPattern) {
+      attributesMapBi.put(BiFields.VALIDATION_PATTERN.getFieldName(), 1);
+      attributesMapBi.put(BiFields.VALIDATION.getFieldName(), 1);
+    }
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TextField.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TextField.java
@@ -1,15 +1,19 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.TextFieldNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -188,6 +192,57 @@ public class TextField extends FormElement implements RegexElement, LabelableEle
   }
 
   @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    this.putTypeIfPresent(attributesMapBi);
+    this.putOneIfPresent(attributesMapBi, BiFields.TITLE.getFieldName(), TITLE);
+    this.putOneIfPresent(attributesMapBi, BiFields.PLACEHOLDER.getFieldName(), PLACEHOLDER_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getFieldName(), LABEL);
+    this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getFieldName(), REQUIRED_ATTR);
+    this.computeAndPutValidationProperties(attributesMapBi);
+
+    if (this.hasElementInitialValue()) {
+      attributesMapBi.put(BiFields.DEFAULT.getFieldName(), 1);
+    }
+
+    context.addItem(new BiItem(BiFields.TEXT_FIELD.getFieldName(), attributesMapBi));
+  }
+
+  private void putTypeIfPresent(Map<String, Object> attributesMap) {
+    String value = getAttributes().get(MASKED_ATTR);
+
+    if (value != null && Boolean.TRUE.equals(Boolean.valueOf(value))) {
+      attributesMap.put(BiFields.TYPE.getFieldName(), BiFields.TYPE_MASKED_TRUE.getFieldName());
+    } else if (value != null && Boolean.FALSE.equals(Boolean.valueOf(value))) {
+      attributesMap.put(BiFields.TYPE.getFieldName(), BiFields.TYPE_MASKED_FALSE.getFieldName());
+    }
+  }
+
+  private void computeAndPutValidationProperties(Map<String, Object> attributesMapBi) {
+    boolean validationMin = getAttribute(MINLENGTH_ATTR) != null;
+    boolean validationMax = getAttribute(MAXLENGTH_ATTR) != null;
+    boolean validationPattern = getAttribute(PATTERN_ATTR) != null;
+    boolean hasValidation = validationMin || validationMax || validationPattern;
+
+    if (validationMin) {
+      attributesMapBi.put(BiFields.VALIDATION_MIN.getFieldName(), 1);
+    }
+
+    if (validationMax) {
+      attributesMapBi.put(BiFields.VALIDATION_MAX.getFieldName(), 1);
+    }
+
+    if (validationPattern) {
+      attributesMapBi.put(BiFields.VALIDATION_PATTERN.getFieldName(), 1);
+    }
+
+    if (hasValidation) {
+      attributesMapBi.put(BiFields.VALIDATION.getFieldName(), 1);
+    }
+  }
+
+  @Override
   public String getPresentationMLTag() {
     return INPUT_TAG;
   }
@@ -202,33 +257,33 @@ public class TextField extends FormElement implements RegexElement, LabelableEle
     return ELEMENT_ID;
   }
 
-    @Override
-    public String getElementType() {
-        return MESSAGEML_TAG;
-    }
+  @Override
+  public String getElementType() {
+    return MESSAGEML_TAG;
+  }
 
-    @Override
-    public boolean hasElementInitialValue() {
-        return getChildren() != null && getChildren().size() == 1 && getChild(0) instanceof TextNode;
-    }
+  @Override
+  public boolean hasElementInitialValue() {
+    return getChildren() != null && getChildren().size() == 1 && getChild(0) instanceof TextNode;
+  }
 
-    @Override
-    public String getElementInitialValue() {
-        return ((TextNode) getChild(0)).getText();
-    }
+  @Override
+  public String getElementInitialValue() {
+    return ((TextNode) getChild(0)).getText();
+  }
 
-    @Override
-    public String getAttributeValue(String attributeName) {
-        return getAttribute(attributeName);
-    }
+  @Override
+  public String getAttributeValue(String attributeName) {
+    return getAttribute(attributeName);
+  }
 
-    @Override
-    public Integer getMinValueAllowed() {
-        return MIN_ALLOWED_LENGTH;
-    }
+  @Override
+  public Integer getMinValueAllowed() {
+    return MIN_ALLOWED_LENGTH;
+  }
 
-    @Override
-    public Integer getMaxValueAllowed() {
-        return MAX_ALLOWED_LENGTH;
-    }
+  @Override
+  public Integer getMaxValueAllowed() {
+    return MAX_ALLOWED_LENGTH;
+  }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TimePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TimePicker.java
@@ -3,8 +3,11 @@ package org.symphonyoss.symphony.messageml.elements;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.TimePickerNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.symphonyoss.symphony.messageml.util.XMLAttribute;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 import org.symphonyoss.symphony.messageml.util.pojo.TimeInterval;
@@ -12,6 +15,7 @@ import org.w3c.dom.Node;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -131,6 +135,54 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
     return new TimePickerNode(getAttribute(LABEL), getAttribute(TITLE), getAttribute(PLACEHOLDER_ATTR));
   }
 
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    this.putOneIfPresent(attributesMapBi, BiFields.TITLE.getFieldName(), TITLE);
+    this.putOneIfPresent(attributesMapBi, BiFields.PLACEHOLDER.getFieldName(), PLACEHOLDER_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getFieldName(), LABEL);
+    this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getFieldName(), REQUIRED_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.DEFAULT.getFieldName(), VALUE_ATTR);
+    this.putIntegerIfPresent(attributesMapBi, BiFields.INPUT_STEP.getFieldName(), STEP_ATTR);
+    this.computeAndPutValidationProperties(attributesMapBi);
+
+    context.addItem(new BiItem(BiFields.TIME_PICKER.getFieldName(), attributesMapBi));
+  }
+
+  private void computeAndPutValidationProperties(Map<String, Object> attributesMapBi) {
+    boolean validationMin = getAttribute(MIN_ATTR) != null;
+    boolean validationMax = getAttribute(MAX_ATTR) != null;
+    boolean validationPattern = getAttribute(FORMAT_ATTR) != null;
+    boolean validationOptions = getAttribute(DISABLED_TIME_ATTR) != null;
+    boolean validationStrict = getAttribute(STRICT_ATTR) != null;
+    boolean hasValidation = validationMin || validationMax || validationPattern || validationOptions
+        || validationStrict;
+
+    if (validationMin) {
+      attributesMapBi.put(BiFields.VALIDATION_MIN.getFieldName(), 1);
+    }
+
+    if (validationMax) {
+      attributesMapBi.put(BiFields.VALIDATION_MAX.getFieldName(), 1);
+    }
+
+    if (validationPattern) {
+      attributesMapBi.put(BiFields.VALIDATION_PATTERN.getFieldName(), 1);
+    }
+
+    if (validationOptions) {
+      attributesMapBi.put(BiFields.VALIDATION_OPTIONS.getFieldName(), 1);
+    }
+
+    if (validationStrict) {
+      attributesMapBi.put(BiFields.VALIDATION_STRICT.getFieldName(), 1);
+    }
+
+    if (hasValidation) {
+      attributesMapBi.put(BiFields.VALIDATION.getFieldName(), 1);
+    }
+  }
 
   private void innerAsPresentationML(XmlPrintStream out, Map<String, Object> presentationAttrs) {
     out.printElement(PRESENTATIONML_TAG, presentationAttrs);

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TimezonePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TimezonePicker.java
@@ -3,8 +3,11 @@ package org.symphonyoss.symphony.messageml.elements;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.form.TimezonePickerNode;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.symphonyoss.symphony.messageml.util.XMLAttribute;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 import org.w3c.dom.Node;
@@ -12,6 +15,7 @@ import org.w3c.dom.Node;
 import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,6 +148,29 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
       out.closeElement();
     } else {
       innerAsPresentationML(out, presentationAttrs);
+    }
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    this.putOneIfPresent(attributesMapBi, BiFields.TITLE.getFieldName(), TITLE);
+    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getFieldName(), LABEL);
+    this.putOneIfPresent(attributesMapBi, BiFields.PLACEHOLDER.getFieldName(), PLACEHOLDER_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getFieldName(), REQUIRED_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.DEFAULT.getFieldName(), VALUE_ATTR);
+    this.computeAndPutValidationProperties(attributesMapBi);
+
+    context.addItem(new BiItem(BiFields.TIMEZONE_PICKER.getFieldName(), attributesMapBi));
+  }
+
+  private void computeAndPutValidationProperties(Map<String, Object> attributesMapBi) {
+    boolean validationOptions = getAttribute(DISABLED_TIMEZONE_ATTR) != null;
+
+    if (validationOptions) {
+      attributesMapBi.put(BiFields.VALIDATION_OPTIONS.getFieldName(), 1);
+      attributesMapBi.put(BiFields.VALIDATION.getFieldName(), 1);
     }
   }
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/util/BiFields.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/util/BiFields.java
@@ -1,0 +1,54 @@
+package org.symphonyoss.symphony.messageml.util;
+
+public enum BiFields {
+
+  FORM("Form", "form"),
+  BUTTON("Button", "button"),
+  TEXT_AREA("TextArea", "textarea"),
+  TEXT_FIELD("TextField", "text-field"),
+  CHECKBOX("CheckBox", "checkbox"),
+  RADIO("Radio", "radio"),
+  TIME_PICKER("TimePicker", "time-picker"),
+  TIMEZONE_PICKER("TimeZonePicker", "timezone-picker"),
+  DATE_SELECTOR("DateSelector", "date-picker"),
+  PERSON_SELECTOR("PersonSelector", "person-selector"),
+  SELECT("Dropdown Menu", "select"),
+  OPTION("Option", "option"),
+  ENTITY("Entity", "entity"),
+  INPUT_STEP("Input_Step", "step"),
+  TITLE("Title", "title"),
+  DEFAULT("Default", "default"),
+  PLACEHOLDER("Placeholder", "placeholder"),
+  STYLE_COLOR("StyleColor", "class"),
+  TYPE("Type", "type"),
+  TYPE_MASKED_TRUE("Masked", null),
+  TYPE_MASKED_FALSE("Normal", null),
+  ENTITY_TYPE("EntityType", "type"),
+  LABEL("Label", "label"),
+  OPTIONS_COUNT("OptionsCount", null),
+  VALIDATION("Validation", null),
+  VALIDATION_MAX("Validation_Max", null),
+  VALIDATION_MIN("Validation_Min", null),
+  VALIDATION_PATTERN("Validation_Pattern", null),
+  VALIDATION_OPTIONS("Validation_Options", null),
+  HIGHLIGHTED_OPTIONS("HighlightedOptions", null),
+  VALIDATION_STRICT("Validation_Strict", null),
+  REQUIRED("Required", "required");
+
+  private String fieldName;
+  private String messageMlAttribute;
+
+  BiFields(String fieldName, String messageMlAttribute) {
+    this.fieldName = fieldName;
+    this.messageMlAttribute = messageMlAttribute;
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  public String getMessageMlAttribute() {
+    return messageMlAttribute;
+  }
+
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
@@ -48,6 +48,7 @@ import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.elements.TextNode;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 import org.symphonyoss.symphony.messageml.util.IDataProvider;
 import org.symphonyoss.symphony.messageml.util.UserPresentation;
 import org.w3c.dom.Document;
@@ -58,6 +59,7 @@ import org.xml.sax.InputSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -371,22 +373,21 @@ public class MessageMLContextTest {
     Map<String, Object> expectedFormAttrs = new HashMap<>();
     expectedFormAttrs.put("form", 1);
     Map<String, Object> expectedButtonAttrs = new HashMap<>();
-    expectedButtonAttrs.put("class", "primary");
-    expectedButtonAttrs.put("type", "action");
-    expectedButtonAttrs.put("title", 1);
+    expectedButtonAttrs.put(BiFields.STYLE_COLOR.getFieldName(), "primary");
+    expectedButtonAttrs.put(BiFields.TYPE.getFieldName(), "action");
 
     context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
     BiContext biContext = context.getBiContext();
 
     assertEquals(2, biContext.getItems().size());
 
-    BiItem formItem = biContext.getItems().get(0);
-    assertEquals("Form", formItem.getName());
-    assertEquals(expectedFormAttrs , formItem.getAttributes());
-
-    BiItem buttonItem = biContext.getItems().get(1);
-    assertEquals("Button", buttonItem.getName());
+    BiItem buttonItem = biContext.getItems().get(0);
+    assertEquals(BiFields.BUTTON.getFieldName(), buttonItem.getName());
     assertEquals(expectedButtonAttrs , buttonItem.getAttributes());
+
+    BiItem formItem = biContext.getItems().get(1);
+    assertEquals(BiFields.FORM.getFieldName(), formItem.getName());
+    assertEquals(expectedFormAttrs , formItem.getAttributes());
   }
 
   @Test
@@ -403,14 +404,13 @@ public class MessageMLContextTest {
     BiContext biContext = context.getBiContext();
 
     Map<String, Object> expectedButtonAttrs = new HashMap<>();
-    expectedButtonAttrs.put("class", "primary");
-    expectedButtonAttrs.put("type", "action");
-    expectedButtonAttrs.put("title", "");
+    expectedButtonAttrs.put(BiFields.STYLE_COLOR.getFieldName(), "primary");
+    expectedButtonAttrs.put(BiFields.TYPE.getFieldName(), "action");
 
     assertEquals(3, biContext.getItems().size());
-    assertEquals("Form", biContext.getItems().get(0).getName());
-    assertEquals("TextField", biContext.getItems().get(1).getName());
-    BiItem buttonItem = biContext.getItems().get(2);
+    assertEquals("TextField", biContext.getItems().get(0).getName());
+    assertEquals("Form", biContext.getItems().get(2).getName());
+    BiItem buttonItem = biContext.getItems().get(1);
     assertEquals("Button", buttonItem.getName());
     assertEquals(expectedButtonAttrs, buttonItem.getAttributes());
   }
@@ -429,9 +429,9 @@ public class MessageMLContextTest {
     BiContext biContext = context.getBiContext();
 
     assertEquals(3, biContext.getItems().size());
-    assertEquals("Form", biContext.getItems().get(0).getName());
+    assertEquals("Button", biContext.getItems().get(0).getName());
     assertEquals("Button", biContext.getItems().get(1).getName());
-    assertEquals("Button", biContext.getItems().get(2).getName());
+    assertEquals("Form", biContext.getItems().get(2).getName());
   }
 
   @Test
@@ -443,24 +443,27 @@ public class MessageMLContextTest {
               "<emoji shortcode=\"smiley\"/>" +
             "</messageML>";
 
-    Map<String, Object> expectedLinkAttrs = new HashMap<>();
-    expectedLinkAttrs.put("href", 2);
-    Map<String, Object> expectedEmojisAttrs = new HashMap<>();
-    expectedEmojisAttrs.put("emoji", 1);
+    Map<String, Object> expectedLinkAttrs = Collections.singletonMap("href", 2);
+    Map<String, Object> expectedEmojisAttrs = Collections.singletonMap("emoji", 1);
+    Map<String, Object> expectedEntityAttrs = Collections.singletonMap(BiFields.ENTITY_TYPE.getFieldName(), null);
 
     context.parseMessageML(message, "", MessageML.MESSAGEML_VERSION);
     BiContext biContext = context.getBiContext();
 
     List<BiItem> biItems = biContext.getItems();
-    assertEquals(2, biItems.size());
+    assertEquals(3, biItems.size());
 
     BiItem linkItem = biItems.get(0);
     assertEquals("Link", linkItem.getName());
     assertEquals(expectedLinkAttrs, linkItem.getAttributes());
 
     BiItem emojiItem = biItems.get(1);
-    assertEquals("Emoji", biItems.get(1).getName());
+    assertEquals("Emoji", emojiItem.getName());
     assertEquals(expectedEmojisAttrs, emojiItem.getAttributes());
+
+    BiItem entityItem = biItems.get(2);
+    assertEquals(BiFields.ENTITY.getFieldName(), entityItem.getName());
+    assertEquals(expectedEntityAttrs, entityItem.getAttributes());
   }
 
   @Test

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/CashtagTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/CashtagTest.java
@@ -5,9 +5,15 @@ import static org.junit.Assert.assertNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Test;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 public class CashtagTest extends ElementTest {
 
@@ -202,6 +208,26 @@ public class CashtagTest extends ElementTest {
     context.parseMessageML(invalidElement, null, MessageML.MESSAGEML_VERSION);
   }
 
+  @Test
+  public void testBiContextMentionEntity() throws InvalidInputException, IOException,
+      ProcessingException {
+
+    String input = "<messageML>Hello <cash tag=\"world\"/>!</messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = context.getBiContext().getItems();
+
+    Map<String, Object> cashTagExpectedAttributes =
+        Collections.singletonMap(CashTag.MESSAGEML_TAG, 1);
+    Map<String, Object> entityExpectedAttributes =
+        Collections.singletonMap(BiFields.ENTITY_TYPE.getFieldName(), "org.symphonyoss.fin.security.id.ticker");
+
+    BiItem cashTagBiItemExpected = new BiItem(CashTag.class.getSimpleName(), cashTagExpectedAttributes);
+    BiItem entityBiItemExpected = new BiItem(BiFields.ENTITY.getFieldName(), entityExpectedAttributes);
+
+    assertEquals(2, items.size());
+    assertSameBiItem(cashTagBiItemExpected, items.get(0));
+    assertSameBiItem(entityBiItemExpected, items.get(1));
+  }
 
   private void verifyCashTag(Element messageML, String expectedPresentationML, String expectedJson, String expectedText,
       String expectedMarkdown) throws Exception {

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/ElementTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/ElementTest.java
@@ -29,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.util.IDataProvider;
 import org.symphonyoss.symphony.messageml.util.TestDataProvider;
@@ -291,6 +292,12 @@ public class ElementTest {
       assertEquals("Exception class", InvalidInputException.class, e.getClass());
       assertEquals("Exception message", "Element \"body\" can only be a child of the following elements: [card]", e.getMessage());
     }
+  }
+
+  protected void assertSameBiItem(BiItem expected, BiItem actual) {
+    // assertEquals(actual, expected);
+    assertEquals(expected.getName(), actual.getName());
+    assertEquals(expected.getAttributes(), actual.getAttributes());
   }
 
 }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/EmojiTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/EmojiTest.java
@@ -7,7 +7,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 public class EmojiTest extends ElementTest{
 
@@ -91,6 +99,27 @@ public class EmojiTest extends ElementTest{
     assertEquals("Markdown", expectedMarkdown, context.getMarkdown());
     assertEquals("EntityJSON", new ObjectNode(JsonNodeFactory.instance), context.getEntityJson());
     assertEquals("Legacy entities", new ObjectNode(JsonNodeFactory.instance) , context.getEntities());
+  }
+
+  @Test
+  public void testBiContextMentionEntity() throws InvalidInputException, IOException,
+      ProcessingException {
+    String input = "<messageML><emoji shortcode=\"smiley\">Test of content</emoji></messageML>";
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = context.getBiContext().getItems();
+
+    Map<String, Object> emojiExpectedAttributes =
+        Collections.singletonMap(Emoji.MESSAGEML_TAG, 1);
+    Map<String, Object> entityExpectedAttributes =
+        Collections.singletonMap(BiFields.ENTITY_TYPE.getFieldName(), null);
+
+    BiItem emojiBiItemExpected = new BiItem(Emoji.class.getSimpleName(), emojiExpectedAttributes);
+    BiItem entityBiItemExpected = new BiItem(BiFields.ENTITY.getFieldName(), entityExpectedAttributes);
+
+    assertEquals(2, items.size());
+    assertSameBiItem(emojiBiItemExpected, items.get(0));
+    assertSameBiItem(entityBiItemExpected, items.get(1));
   }
 
   private void verifyEmojiPresentation(Emoji emoji, String shortcode, String family, String size, String unicode) throws

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/HashtagTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/HashtagTest.java
@@ -5,9 +5,15 @@ import static org.junit.Assert.assertNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Test;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 public class HashtagTest extends ElementTest {
 
@@ -194,6 +200,27 @@ public class HashtagTest extends ElementTest {
     expectedException.expect(InvalidInputException.class);
     expectedException.expectMessage("Shorthand tag \"hash\" is not allowed in PresentationML");
     context.parseMessageML(invalidElement, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testBiContextMentionEntity() throws InvalidInputException, IOException,
+      ProcessingException {
+    String input = "<messageML>Hello <hash tag=\"world\"/>!</messageML>";
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = context.getBiContext().getItems();
+
+    Map<String, Object> hashTagExpectedAttributes =
+        Collections.singletonMap(HashTag.MESSAGEML_TAG, 1);
+    Map<String, Object> entityExpectedAttributes =
+        Collections.singletonMap(BiFields.ENTITY_TYPE.getFieldName(), "org.symphonyoss.taxonomy.hashtag");
+
+    BiItem hashTagBiItemExpected = new BiItem(HashTag.class.getSimpleName(), hashTagExpectedAttributes);
+    BiItem entityBiItemExpected = new BiItem(BiFields.ENTITY.getFieldName(), entityExpectedAttributes);
+
+    assertEquals(2, items.size());
+    assertSameBiItem(hashTagBiItemExpected, items.get(0));
+    assertSameBiItem(entityBiItemExpected, items.get(1));
   }
 
   private void verifyHashTag(Element messageML, String expectedPresentationML, String expectedJson, String expectedText,

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
@@ -8,15 +8,24 @@ import static org.symphonyoss.symphony.messageml.elements.Button.ACTION_TYPE;
 import static org.symphonyoss.symphony.messageml.elements.Button.RESET_TYPE;
 
 import org.junit.Test;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.Button;
 import org.symphonyoss.symphony.messageml.elements.Element;
 import org.symphonyoss.symphony.messageml.elements.ElementTest;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ButtonTest extends ElementTest {
 
@@ -339,6 +348,29 @@ public class ButtonTest extends ElementTest {
     expectedException.expect(InvalidInputException.class);
     expectedException.expectMessage("Attributes \"type\" and \"name\" are not allowed on a button inside a UIAction.");
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testBiContextButton() throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+    String input = "<messageML>"
+        + "<form id=\"all-elements\">"
+        + "<button name=\"name01\" class=\"primary\" type=\"action\">Button Text</button>"
+        + "</form>"
+        + "</messageML>";
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    Map<String, Object> buttonExpectedAttributes = Stream.of(new String[][] {
+        {BiFields.STYLE_COLOR.getFieldName(), "primary"},
+        {BiFields.TYPE.getFieldName(), "action"},
+    }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
+
+    BiItem buttonBiItemExpected = new BiItem(BiFields.BUTTON.getFieldName(), buttonExpectedAttributes);
+
+    assertEquals(2, items.size());
+    assertSameBiItem(buttonBiItemExpected, items.get(0));
   }
 
   private String getNamePresentationML(String name) {

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/CheckboxTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/CheckboxTest.java
@@ -3,16 +3,29 @@ package org.symphonyoss.symphony.messageml.elements.form;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.Checkbox;
 import org.symphonyoss.symphony.messageml.elements.Element;
 import org.symphonyoss.symphony.messageml.elements.ElementTest;
 import org.symphonyoss.symphony.messageml.elements.Form;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CheckboxTest extends ElementTest {
   private String formId;
@@ -353,6 +366,61 @@ public class CheckboxTest extends ElementTest {
     expectedException.expectMessage("Element \"form\" cannot have more than 50 children of the following elements: [checkbox, radio].");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  private static Stream<Arguments> messageMlStream() {
+    return Stream.of(
+        Arguments.of(
+            "<checkbox name=\"id1\">Red</checkbox>"
+                + "<checkbox name=\"id2\" value=\"value02\" checked=\"false\">Green</checkbox>"
+                + "<checkbox name=\"id3\" value=\"value03\" label=\"labelOne\" checked=\"true\">Red</checkbox>"
+                + "<checkbox name=\"id4\" value=\"value04\" checked=\"false\">Yellow</checkbox>"
+                + "<checkbox name=\"id5\" value=\"value02\" label=\"labelTwo\" checked=\"true\">Blue</checkbox>",
+            Stream.of(new Object[][] {
+                {BiFields.LABEL.getFieldName(), 2},
+                {BiFields.OPTIONS_COUNT.getFieldName(), 5},
+                {BiFields.DEFAULT.getFieldName(), 1},
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1]))),
+
+        Arguments.of(
+            "<checkbox name=\"id1\">Red</checkbox>"
+                + "<checkbox name=\"id2\" value=\"value02\">Green</checkbox>"
+                + "<checkbox name=\"id3\" value=\"value03\" label=\"labelOne\">Red</checkbox>"
+                + "<checkbox name=\"id4\" value=\"value04\" checked=\"false\">Yellow</checkbox>"
+                + "<checkbox name=\"id5\" value=\"value02\" label=\"labelTwo\">Blue</checkbox>",
+            Stream.of(new Object[][] {
+                {BiFields.LABEL.getFieldName(), 2},
+                {BiFields.OPTIONS_COUNT.getFieldName(), 5},
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1])))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("messageMlStream")
+  void testBiContextCheckBox_checked(String checkBoxML, Map<String, Object> expectedAttributes)
+      throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+
+    String input = String.format(
+        "<messageML>\n "
+            + "<form id=\"form_id\">\n "
+            + "%s\n"
+            + "<button name=\"name01\">Submit</button>"
+            + "</form>\n </messageML>",
+        checkBoxML);
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    BiItem checkBoxBiItemExpected = new BiItem(BiFields.CHECKBOX.getFieldName(),
+        expectedAttributes.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    Assertions.assertEquals(3, items.size());
+    Assertions.assertEquals(BiFields.CHECKBOX.getFieldName(), items.get(0).getName());
+    assertSameBiItem(checkBoxBiItemExpected, items.get(0));
   }
 
   private String buildMessageMLFromParameters(String name, String value, String text, String checked, boolean shouldSendCheckedAttribute) {

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
@@ -5,15 +5,28 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.DatePicker;
 import org.symphonyoss.symphony.messageml.elements.Element;
 import org.symphonyoss.symphony.messageml.elements.ElementTest;
 import org.symphonyoss.symphony.messageml.elements.Form;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author enrico.molino (17/11/2020)
@@ -430,6 +443,84 @@ public class DatePickerTest extends ElementTest {
         + "---\n";
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
     assertEquals("Markdown", EXPECTED_MARKDOWN, context.getMarkdown());
+  }
+
+  private static Stream<Arguments> messageMlStream() {
+    return Stream.of(
+        Arguments.of(
+            "<date-picker name=\"rules\" value=\"2020-08-28\" label=\"label01\" "
+                + "title=\"title01\" min=\"2021-01-04\" max=\"2021-01-27\" "
+                + "disabled-date='[{\"from\": \"2021-01-13\", \"to\": \"2021-01-15\"},"
+                + " {\"from\": \"2021-01-19\", \"to\": \"2021-01-21\"}, {\"day\": \"2021-01-06\"}, "
+                + "{\"daysOfWeek\": [0,6]}]' "
+                + "highlighted-date='[{\"day\": \"2021-01-05\"}, {\"day\": \"2021-01-26\"}]' "
+                + "format=\"ddMMyyyy\" "
+                + "placeholder=\"placeholder01\" required=\"true\"/>",
+            Stream.of(new Object[][] {
+                {BiFields.PLACEHOLDER.getFieldName(), 1},
+                {BiFields.TITLE.getFieldName(), 1},
+                {BiFields.LABEL.getFieldName(), 1},
+                {BiFields.DEFAULT.getFieldName(), 1},
+                {BiFields.VALIDATION.getFieldName(), 1},
+                {BiFields.VALIDATION_OPTIONS.getFieldName(), 1},
+                {BiFields.VALIDATION_MIN.getFieldName(), 1},
+                {BiFields.VALIDATION_MAX.getFieldName(), 1},
+                {BiFields.VALIDATION_PATTERN.getFieldName(), 1},
+                {BiFields.HIGHLIGHTED_OPTIONS.getFieldName(), 1},
+                {BiFields.REQUIRED.getFieldName(), 1},
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1]))),
+
+        Arguments.of(
+            "<date-picker name=\"rules\" value=\"2020-08-28\" label=\"label01\" "
+                + "title=\"title01\" min=\"2021-01-04\" max=\"2021-01-27\" "
+                + "disabled-date='[{\"from\": \"2021-01-13\", \"to\": \"2021-01-15\"},"
+                + " {\"from\": \"2021-01-19\", \"to\": \"2021-01-21\"}, {\"day\": \"2021-01-06\"}, "
+                + "{\"daysOfWeek\": [0,6]}]' "
+                + "highlighted-date='[{\"day\": \"2021-01-05\"}, {\"day\": \"2021-01-26\"}]' "
+                + "format=\"ddMMyyyy\" "
+                + "placeholder=\"placeholder01\" required=\"true\"/>",
+            Stream.of(new Object[][] {
+                {BiFields.PLACEHOLDER.getFieldName(), 1},
+                {BiFields.TITLE.getFieldName(), 1},
+                {BiFields.LABEL.getFieldName(), 1},
+                {BiFields.DEFAULT.getFieldName(), 1},
+                {BiFields.VALIDATION.getFieldName(), 1},
+                {BiFields.VALIDATION_OPTIONS.getFieldName(), 1},
+                {BiFields.VALIDATION_MIN.getFieldName(), 1},
+                {BiFields.VALIDATION_MAX.getFieldName(), 1},
+                {BiFields.VALIDATION_PATTERN.getFieldName(), 1},
+                {BiFields.HIGHLIGHTED_OPTIONS.getFieldName(), 1},
+                {BiFields.REQUIRED.getFieldName(), 1},
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1])))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("messageMlStream")
+  void testBiContextDatePicker_withValidations(String dataPickerML, Map<String, Object> expectedAttributes)
+      throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+
+    String input = String.format(
+        "<messageML>\n "
+            + "<form id=\"form_id\">\n "
+            + "%s\n"
+            + "<button name=\"name01\">Submit</button>"
+            + "</form>\n </messageML>",
+        dataPickerML);
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    BiItem datePickerBiItemExpected = new BiItem(BiFields.DATE_SELECTOR.getFieldName(),
+        expectedAttributes.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    Assertions.assertEquals(3, items.size());
+    Assertions.assertEquals(BiFields.DATE_SELECTOR.getFieldName(), items.get(0).getName());
+    assertSameBiItem(datePickerBiItemExpected, items.get(0));
   }
 
 }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DateSelectorTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DateSelectorTest.java
@@ -1,15 +1,25 @@
 package org.symphonyoss.symphony.messageml.elements.form;
 
 import org.junit.Test;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.DateSelector;
 import org.symphonyoss.symphony.messageml.elements.Element;
 import org.symphonyoss.symphony.messageml.elements.ElementTest;
 import org.symphonyoss.symphony.messageml.elements.Form;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
 import static org.junit.Assert.assertEquals;
 import static org.symphonyoss.symphony.messageml.markdown.MarkdownRenderer.addEscapeCharacter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DateSelectorTest extends ElementTest {
   private static final String FORM_ID_ATTR = "id";
@@ -85,6 +95,39 @@ public class DateSelectorTest extends ElementTest {
     assertEquals("<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"" + FORM_ID_ATTR +
         "\"><div><div class=\"date-selector\" data-name=\"some-name\"></div></div>" + ACTION_BTN_ELEMENT + "</form></div>", context.getPresentationML());
     assertEquals("Form (log into desktop client to answer):\n---\n(Date Selector)\n\n" + ACTION_BTN_MARKDOWN + "\n---\n", context.getMarkdown());
+  }
+
+  @Test
+  public void testBiContextDateSelector()
+      throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+    String input = "<messageML>"
+        + "<form id=\"form_id\">"
+
+        + "<date-selector name=\"rules\" "
+        + "placeholder=\"placeholder01\" required=\"true\"/>"
+
+        + "<button name=\"date-picker\">Submit</button>"
+        + "</form>"
+        + "</messageML>";
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    Map<Object, Object> expectedAttributes = Stream.of(new Object[][] {
+        {BiFields.PLACEHOLDER.getFieldName(), 1},
+        {BiFields.REQUIRED.getFieldName(), 1},
+    }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
+
+    BiItem datePickerBiItemExpected = new BiItem(BiFields.DATE_SELECTOR.getFieldName(),
+        expectedAttributes.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    assertEquals(3, items.size());
+    assertEquals(BiFields.DATE_SELECTOR.getFieldName(), items.get(0).getName());
+    assertSameBiItem(datePickerBiItemExpected, items.get(0));
   }
 
   private void assertDataFromValidParsedTag(String dataName, String dataPlaceholder, Boolean dataRequired) {

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/FormTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/FormTest.java
@@ -1,10 +1,18 @@
 package org.symphonyoss.symphony.messageml.elements.form;
 
 import org.junit.Test;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.*;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
 import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 public class FormTest extends ElementTest {
   private static final String ID_ATTR = "id";
@@ -87,6 +95,26 @@ public class FormTest extends ElementTest {
     expectedException.expect(InvalidInputException.class);
     expectedException.expectMessage("Elements must have unique ids. The following value is not unique: [" + notUniqueId + "].");
     context.parseMessageML(message, null, MessageML.MESSAGEML_VERSION);
+  }
+
+
+  @Test
+  public void testBiContextForm() throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+    String input = "<messageML>"
+        + "<form id=\"all-elements\">"
+        + "<button name=\"example-button2\">Button Text</button>"
+        + "</form>"
+        + "</messageML>";
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    BiItem formBiItemExpected = new BiItem(BiFields.FORM.getFieldName(),
+        Collections.singletonMap(BiFields.FORM.getMessageMlAttribute(), 1));
+
+    assertEquals(2, items.size());
+    assertSameBiItem(formBiItemExpected, items.get(1));
   }
 
   private String getExpectedFormPresentationML(Form form) {

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/PersonSelectorTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/PersonSelectorTest.java
@@ -1,15 +1,24 @@
 package org.symphonyoss.symphony.messageml.elements.form;
 
 import org.junit.Test;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.Element;
 import org.symphonyoss.symphony.messageml.elements.ElementTest;
 import org.symphonyoss.symphony.messageml.elements.Form;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.elements.PersonSelector;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.symphonyoss.symphony.messageml.markdown.MarkdownRenderer.addEscapeCharacter;
@@ -207,6 +216,54 @@ public class PersonSelectorTest extends ElementTest {
         "\"><div><div class=\"person-selector\" data-name=\"some-name\"></div></div>" + ACTION_BTN_ELEMENT + "</form></div>", context.getPresentationML());
     assertEquals("Form (log into desktop client to answer):\n---\n(Person Selector)\n\n" + ACTION_BTN_MARKDOWN
         + "\n---\n", context.getMarkdown());
+  }
+
+  @Test
+  public void testBiContextPersonSelector()
+      throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+    String input = "<messageML>"
+        + "<form id=\"form_id\">"
+        + "<person-selector name=\"name01\" title=\"title01\" label=\"label01\" "
+        + "placeholder=\"placeholder01\" required=\"true\"/>"
+        + "<person-selector name=\"name02\" title=\"title02\" "
+        + "placeholder=\"placeholder02\"/>"
+        + "<button name=\"person-selector\">Submit</button>"
+        + "</form>"
+        + "</messageML>";
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    Map<Object, Object> expectedAttributesFirst = Stream.of(new Object[][] {
+        {BiFields.PLACEHOLDER.getFieldName(), 1},
+        {BiFields.TITLE.getFieldName(), 1},
+        {BiFields.LABEL.getFieldName(), 1},
+        {BiFields.REQUIRED.getFieldName(), 1},
+    }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
+
+    Map<Object, Object> expectedAttributesSecond = Stream.of(new Object[][] {
+        {BiFields.PLACEHOLDER.getFieldName(), 1},
+        {BiFields.TITLE.getFieldName(), 1},
+    }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
+
+    BiItem personSelectorFirstBiItemExpected = new BiItem(BiFields.PERSON_SELECTOR.getFieldName(),
+        expectedAttributesFirst.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    BiItem personSelectorSecondBiItemExpected = new BiItem(BiFields.PERSON_SELECTOR.getFieldName(),
+        expectedAttributesSecond.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    assertEquals(4, items.size());
+    assertEquals(BiFields.PERSON_SELECTOR.getFieldName(), items.get(0).getName());
+    assertEquals(BiFields.PERSON_SELECTOR.getFieldName(), items.get(1).getName());
+    assertSameBiItem(personSelectorFirstBiItemExpected, items.get(0));
+    assertSameBiItem(personSelectorSecondBiItemExpected, items.get(1));
   }
 
   private void assertDataFromValidParsedTag(String dataName, String dataPlaceholder, Boolean dataRequired) {

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/RadioTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/RadioTest.java
@@ -6,12 +6,26 @@ import static org.junit.Assert.assertTrue;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.Element;
 import org.symphonyoss.symphony.messageml.elements.ElementTest;
 import org.symphonyoss.symphony.messageml.elements.Form;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.elements.Radio;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class RadioTest extends ElementTest {
   private String formId;
@@ -537,6 +551,60 @@ public class RadioTest extends ElementTest {
     expectedException.expectMessage("Element \"form\" cannot have more than 50 children of the following elements: [checkbox, radio].");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+    private static Stream<Arguments> messageMlStream() {
+    return Stream.of(
+        Arguments.of(
+            "<radio name=\"groupId\" value=\"value01\" checked=\"true\">red</radio>"
+                + "<radio name=\"groupId\" value=\"value02\" label=\"label02\">green</radio>"
+                + "<radio name=\"groupId\" value=\"value03\">blue</radio>"
+                + "<radio name=\"groupId\" value=\"value04\" label=\"label04\" checked=\"false\">yellow</radio>",
+            Stream.of(new Object[][] {
+                {BiFields.LABEL.getFieldName(), 2},
+                {BiFields.OPTIONS_COUNT.getFieldName(), 4},
+                {BiFields.DEFAULT.getFieldName(), 1},
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1]))),
+
+        Arguments.of(
+            "<radio name=\"groupId\" value=\"value01\">red</radio>"
+                + "<radio name=\"groupId\" value=\"value02\" label=\"label02\">green</radio>"
+                + "<radio name=\"groupId\" value=\"value03\">blue</radio>"
+                + "<radio name=\"groupId\" value=\"value04\" label=\"label04\">yellow</radio>",
+            Stream.of(new Object[][] {
+                {BiFields.LABEL.getFieldName(), 2},
+                {BiFields.OPTIONS_COUNT.getFieldName(), 4},
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1])))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("messageMlStream")
+  void testBiContextRadio_checked(String radioML, Map<String, Object> expectedAttributes)
+      throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+
+    String input = String.format(
+        "<messageML>\n "
+            + "<form id=\"form_id\">\n "
+            + "%s\n"
+            + "<button type=\"reset\">Reset</button>"
+            + "<button name=\"radio\">Submit</button>"
+            + "</form>\n </messageML>",
+        radioML);
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    BiItem checkBoxBiItemExpected = new BiItem(BiFields.RADIO.getFieldName(),
+        expectedAttributes.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    Assertions.assertEquals(4, items.size());
+    Assertions.assertEquals(BiFields.RADIO.getFieldName(), items.get(0).getName());
+    assertSameBiItem(checkBoxBiItemExpected, items.get(0));
   }
 
   static String getInputId(String presentationML) {

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/SelectOptionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/SelectOptionTest.java
@@ -1,15 +1,24 @@
 package org.symphonyoss.symphony.messageml.elements.form;
 
 import org.junit.Test;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.Element;
 import org.symphonyoss.symphony.messageml.elements.ElementTest;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.elements.Option;
 import org.symphonyoss.symphony.messageml.elements.Select;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -283,6 +292,56 @@ public class SelectOptionTest extends ElementTest {
     expectedException.expectMessage("Element \"span\" is not allowed in \"select\"");
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testBiContextSelect()
+      throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+    String input = "<messageML>\n"
+        + "  <form id=\"form_id\">\n"
+        + "<select name=\"init\" required=\"true\" title=\"title01\" label=\"label01\" "
+        + "data-placeholder=\"placeholder01\">\n"
+        + "      <option value=\"opt1\">Unselected option 1</option>\n"
+        + "      <option value=\"opt2\" selected=\"true\">With selected option</option>\n"
+        + "      <option value=\"opt3\">Unselected option 2</option>\n"
+        + "      </select>\n"
+        + "      <button name=\"dropdown\">Submit</button>\n"
+        + "  </form>\n"
+        + "</messageML>";
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    Map<Object, Object> selectExpectedAttributes = Stream.of(new Object[][] {
+        {BiFields.TITLE.getFieldName(), 1},
+        {BiFields.LABEL.getFieldName(), 1},
+        {BiFields.PLACEHOLDER.getFieldName(), 1},
+        {BiFields.REQUIRED.getFieldName(), 1},
+    }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
+
+    Map<Object, Object> optionExpectedAttributes = Stream.of(new Object[][] {
+        {BiFields.DEFAULT.getFieldName(), 1},
+        {BiFields.OPTIONS_COUNT.getFieldName(), 3},
+    }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
+
+    BiItem selectBiItemExpected = new BiItem(BiFields.SELECT.getFieldName(),
+        selectExpectedAttributes.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    BiItem optionBiItemExpected = new BiItem(BiFields.OPTION.getFieldName(),
+        optionExpectedAttributes.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    assertEquals(4, items.size());
+    assertEquals(BiFields.OPTION.getFieldName(), items.get(0).getName());
+    assertEquals(BiFields.SELECT.getFieldName(), items.get(1).getName());
+    assertSameBiItem(optionBiItemExpected, items.get(0));
+    assertSameBiItem(selectBiItemExpected, items.get(1));
   }
 
   @Test

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextAreaTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextAreaTest.java
@@ -6,7 +6,13 @@ import static org.junit.Assert.assertTrue;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.rules.ExpectedException;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.Element;
 import org.symphonyoss.symphony.messageml.elements.ElementTest;
 import org.symphonyoss.symphony.messageml.elements.Form;
@@ -14,9 +20,16 @@ import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.elements.RegexElement;
 import org.symphonyoss.symphony.messageml.elements.TextArea;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TextAreaTest extends ElementTest {
 
@@ -387,4 +400,62 @@ public class TextAreaTest extends ElementTest {
 
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
+
+  private static Stream<Arguments> messageMlStream() {
+    return Stream.of(
+        Arguments.of(
+            "<textarea name=\"req\" required=\"true\" label=\"My label\" title=\"title01\" "
+                + "pattern=\"^[a-zA-Z]{3,3}$\" pattern-error-message=\"error message\" "
+                + "placeholder=\"placeholder01\"> With initial value</textarea>\n",
+            Stream.of(new Object[][] {
+                {BiFields.TITLE.getFieldName(), 1},
+                {BiFields.LABEL.getFieldName(), 1},
+                {BiFields.PLACEHOLDER.getFieldName(), 1},
+                {BiFields.DEFAULT.getFieldName(), 1},
+                {BiFields.REQUIRED.getFieldName(), 1},
+                {BiFields.VALIDATION_PATTERN.getFieldName(), 1},
+                {BiFields.VALIDATION.getFieldName(), 1},
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1]))),
+
+
+
+        Arguments.of(
+            "<textarea name=\"req\" required=\"true\" label=\"My label\" title=\"title01\" "
+                + "placeholder=\"placeholder01\"/>\n", Stream.of(new Object[][] {
+                {BiFields.TITLE.getFieldName(), 1},
+                {BiFields.LABEL.getFieldName(), 1},
+                {BiFields.PLACEHOLDER.getFieldName(), 1},
+                {BiFields.REQUIRED.getFieldName(), 1},
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1])))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("messageMlStream")
+  void testBiContextTextArea_withValidation(String textAreaML, Map<String, Object> expectedAttributes)
+      throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+
+    String input = String.format(
+        "<messageML>\n "
+            + "<form id=\"form_id\">\n "
+            + "%s\n"
+            + "<button name=\"name01\">Submit</button>\n "
+            + "</form>\n </messageML>",
+        textAreaML);
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    BiItem textAreaBiItemExpected = new BiItem(BiFields.TEXT_AREA.getFieldName(),
+        expectedAttributes.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    Assertions.assertEquals(3, items.size());
+    Assertions.assertEquals(BiFields.TEXT_AREA.getFieldName(), items.get(0).getName());
+    assertSameBiItem(textAreaBiItemExpected, items.get(0));
+  }
+
 }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
@@ -7,7 +7,13 @@ import static org.symphonyoss.symphony.messageml.markdown.MarkdownRenderer.addEs
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.rules.ExpectedException;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.Element;
 import org.symphonyoss.symphony.messageml.elements.ElementTest;
 import org.symphonyoss.symphony.messageml.elements.Form;
@@ -15,9 +21,16 @@ import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.elements.RegexElement;
 import org.symphonyoss.symphony.messageml.elements.TextField;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TextFieldTest extends ElementTest {
 
@@ -695,6 +708,82 @@ public class TextFieldTest extends ElementTest {
         + ACTION_BTN_ELEMENT
         + "</form></messageML>";
     context.parseMessageML(messageMLInput, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  private static Stream<Arguments> messageMlStream() {
+    return Stream.of(
+        Arguments.of(
+            "<text-field name=\"name01\" title=\"title01\" placeholder=\"placeholder01\" required=\"true\" "
+                + "label=\"label01\" pattern=\"^[a-zA-Z]{3,3}$\" pattern-error-message=\"errorMessage01\" "
+                + "minlength=\"3\" maxlength=\"10\" masked=\"true\">text</text-field>",
+            Stream.of(new Object[][] {
+                {BiFields.TITLE.getFieldName(), 1},
+                {BiFields.LABEL.getFieldName(), 1},
+                {BiFields.PLACEHOLDER.getFieldName(), 1},
+                {BiFields.TYPE.getFieldName(), BiFields.TYPE_MASKED_TRUE.getFieldName()},
+                {BiFields.DEFAULT.getFieldName(), 1},
+                {BiFields.REQUIRED.getFieldName(), 1},
+                {BiFields.VALIDATION_MIN.getFieldName(), 1},
+                {BiFields.VALIDATION_MAX.getFieldName(), 1},
+                {BiFields.VALIDATION_PATTERN.getFieldName(), 1},
+                {BiFields.VALIDATION.getFieldName(), 1},
+
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1]))),
+
+        Arguments.of(
+            "<text-field name=\"name01\" title=\"title01\" placeholder=\"placeholder01\" required=\"true\" "
+                + "label=\"label01\" pattern=\"^[a-zA-Z]{3,3}$\" pattern-error-message=\"errorMessage01\" "
+                + "minlength=\"3\" maxlength=\"10\" masked=\"false\"/>", Stream.of(new Object[][] {
+                {BiFields.TITLE.getFieldName(), 1},
+                {BiFields.LABEL.getFieldName(), 1},
+                {BiFields.PLACEHOLDER.getFieldName(), 1},
+                {BiFields.TYPE.getFieldName(), BiFields.TYPE_MASKED_FALSE.getFieldName()},
+                {BiFields.REQUIRED.getFieldName(), 1},
+                {BiFields.VALIDATION_MIN.getFieldName(), 1},
+                {BiFields.VALIDATION_MAX.getFieldName(), 1},
+                {BiFields.VALIDATION_PATTERN.getFieldName(), 1},
+                {BiFields.VALIDATION.getFieldName(), 1},
+
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1]))),
+
+        Arguments.of(
+            "<text-field name=\"name01\" title=\"title01\" placeholder=\"placeholder01\" required=\"true\" "
+            + "label=\"label01\"/>", Stream.of(new Object[][] {
+                {BiFields.TITLE.getFieldName(), 1},
+                {BiFields.LABEL.getFieldName(), 1},
+                {BiFields.PLACEHOLDER.getFieldName(), 1},
+                {BiFields.REQUIRED.getFieldName(), 1},
+
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1])))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("messageMlStream")
+  void testBiContextTextField_masked_withValidation(String textFieldML, Map<String, Object> expectedAttributes)
+      throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+
+    String input = String.format(
+        "<messageML>\n "
+            + "<form id=\"form_id\">\n "
+            + "%s\n"
+            + "<button name=\"name\">Submit</button>\n "
+            + "</form>\n </messageML>",
+        textFieldML);
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    BiItem textAreaBiItemExpected = new BiItem(BiFields.TEXT_FIELD.getFieldName(),
+        expectedAttributes.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    Assertions.assertEquals(3, items.size());
+    Assertions.assertEquals(BiFields.TEXT_FIELD.getFieldName(), items.get(0).getName());
+    assertSameBiItem(textAreaBiItemExpected, items.get(0));
   }
 
   private String getLabelId(String presentationML) {

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TimePickerTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TimePickerTest.java
@@ -2,13 +2,27 @@ package org.symphonyoss.symphony.messageml.elements.form;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.*;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
+import org.symphonyoss.symphony.messageml.util.BiFields;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class TimePickerTest extends ElementTest {
@@ -359,6 +373,121 @@ public class TimePickerTest extends ElementTest {
             + "---\n";
 
     assertEquals("Markdown", EXPECTED_MARKDOWN, context.getMarkdown());
+  }
+
+  private static Stream<Arguments> messageMlStream() {
+    return Stream.of(
+        Arguments.of(
+            "<time-picker name=\"name01\" label=\"label01\" placeholder=\"placeholder01\" \n "
+                + "title=\"title01\" required=\"true\" value=\"13:51:06\" min=\"08:00:00\" "
+                + "max=\"17:00:00\" format=\"hhmmssa\" disabled-time='[{\"from\": \"12:00:00\", "
+                + "\"to\": \"14:00:00\"}, \n {\"time\": \"15:00:00\"}]' step=\"600\" "
+                + "strict=\"true\"/>",
+            Stream.of(new Object[][] {
+                {BiFields.TITLE.getFieldName(), 1},
+                {BiFields.LABEL.getFieldName(), 1},
+                {BiFields.PLACEHOLDER.getFieldName(), 1},
+                {BiFields.INPUT_STEP.getFieldName(), 600},
+                {BiFields.DEFAULT.getFieldName(), 1},
+                {BiFields.REQUIRED.getFieldName(), 1},
+                {BiFields.VALIDATION_MIN.getFieldName(), 1},
+                {BiFields.VALIDATION_MAX.getFieldName(), 1},
+                {BiFields.VALIDATION_PATTERN.getFieldName(), 1},
+                {BiFields.VALIDATION_OPTIONS.getFieldName(), 1},
+                {BiFields.VALIDATION_STRICT.getFieldName(), 1},
+                {BiFields.VALIDATION.getFieldName(), 1},
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1]))),
+
+        Arguments.of(
+            "<time-picker name=\"name01\" label=\"label01\" placeholder=\"placeholder01\" "
+                + "title=\"title01\" required=\"true\" value=\"13:51:06\"/>",
+            Stream.of(new Object[][] {
+                {BiFields.TITLE.getFieldName(), 1},
+                {BiFields.LABEL.getFieldName(), 1},
+                {BiFields.PLACEHOLDER.getFieldName(), 1},
+                {BiFields.DEFAULT.getFieldName(), 1},
+                {BiFields.REQUIRED.getFieldName(), 1},
+            }).collect(Collectors.toMap(property -> property[0], property -> property[1])))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("messageMlStream")
+  void testBiContextTimePicker_withValidation(String timePickerML,
+      Map<String, Object> expectedAttributes)
+      throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+    String input = String.format(
+        "<messageML>\n "
+            + "<form id=\"form_id\">\n "
+            + "%s\n"
+            + "<button name=\"time-picker\">Submit</button>\n "
+            + "</form>\n </messageML>",
+        timePickerML);
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    BiItem timePickerBiItemExpected = new BiItem(BiFields.TIME_PICKER.getFieldName(),
+        expectedAttributes.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    Assertions.assertEquals(3, items.size());
+    Assertions.assertEquals(BiFields.TIME_PICKER.getFieldName(), items.get(0).getName());
+    assertSameBiItem(timePickerBiItemExpected, items.get(0));
+  }
+
+  @Test
+  public void testBiContextTimePicker_BadAttribute() {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+    String badInput = "<messageML>\n"
+        + "  <form id=\"form_id\">\n"
+        + "      <time-picker name=\"name01\" label=\"label01\" placeholder=\"placeholder01\" "
+        + "title=\"title01\" required=\"true\" value=\"13:51:06\" min=\"08:00:00\" "
+        + "max=\"17:00:00\" format=\"hhmmssa\" disabled-time='[{\"from\": \"12:00:00\", \"to\": "
+        + "\"14:00:00\"}, "
+        + "{\"time\": \"15:00:00\"}]' step=\"abc\" strict=\"true\"/>\n"
+        + "      <button name=\"time-picker\">Submit</button>\n"
+        + "  </form>\n"
+        + "</messageML>";
+
+    Exception exception = assertThrows(Exception.class,
+        () -> messageMLContext.parseMessageML(badInput, null, MessageML.MESSAGEML_VERSION));
+
+    Assertions.assertEquals("Attribute \"step\" should be a number.", exception.getMessage());
+
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    Map<Object, Object> expectedAttributes = Stream.of(new Object[][] {
+        {BiFields.TITLE.getFieldName(), 1},
+        {BiFields.LABEL.getFieldName(), 1},
+        {BiFields.PLACEHOLDER.getFieldName(), 1},
+        {BiFields.DEFAULT.getFieldName(), 1},
+        {BiFields.REQUIRED.getFieldName(), 1},
+        {BiFields.VALIDATION_MIN.getFieldName(), 1},
+        {BiFields.VALIDATION_MAX.getFieldName(), 1},
+        {BiFields.VALIDATION_PATTERN.getFieldName(), 1},
+        {BiFields.VALIDATION_OPTIONS.getFieldName(), 1},
+        {BiFields.VALIDATION_STRICT.getFieldName(), 1},
+        {BiFields.VALIDATION.getFieldName(), 1},
+    }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
+
+    BiItem timePickerBiItemExpected = new BiItem(BiFields.TIME_PICKER.getFieldName(),
+        expectedAttributes.entrySet()
+            .stream()
+            .collect(Collectors.toMap(e ->
+                String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    Assertions.assertEquals(
+        1, items.size(),
+        "As time-picker is firstly parsed and failed, context is not filled with form and button");
+    Assertions.assertNull(
+        items.get(0).getAttributes().get(BiFields.INPUT_STEP),
+        "Input_Step BI property is not set in context as the attribute value is not correct");
+    Assertions.assertEquals(BiFields.TIME_PICKER.getFieldName(), items.get(0).getName());
+    assertSameBiItem(timePickerBiItemExpected, items.get(0));
   }
 
 }


### PR DESCRIPTION
After this implementation #259 we are ready to start filling the BiContext with a list BiItems.
This ticket will take care of elements such as Button, TextField, TextArea... Most of the cases for these elements we want to compute the number of occurrences of the elements it self or in some cases the actual value found inside the message (like for Button StyleColor (primary, destructive..)).

An enum is created to handle BI properties consts.

On the same occasion, a new dependancy is added to junit-jupiter-params to use parameterized tests in order to optimize testing code.