### PR TITLE
MML-271 Add BiEventType to BiFields

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiEventType.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiEventType.java
@@ -3,7 +3,8 @@ package org.symphonyoss.symphony.messageml.bi;
 public enum BiEventType {
 
   MESSAGEML_MESSAGE_SENT("MESSAGEML_MESSAGE_SENT"),
-  MESSAGEML_ELEMENT_SENT("MESSAGEML_ELEMENT_SENT");
+  MESSAGEML_ELEMENT_SENT("MESSAGEML_ELEMENT_SENT"),
+  NONE("NONE");
 
   private final String type;
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiFields.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiFields.java
@@ -69,8 +69,8 @@ public enum BiFields {
   REQUIRED("Required", BiEventType.MESSAGEML_ELEMENT_SENT),
   MESSAGE_LENGTH("MessageLength", BiEventType.MESSAGEML_MESSAGE_SENT),
   ENTITY_JSON_SIZE("EntitiesJSONSize", BiEventType.MESSAGEML_MESSAGE_SENT),
-  FREEMARKER("UseFreeMarker", BiEventType.MESSAGEML_ELEMENT_SENT),
-  COUNT("Count", null);
+  FREEMARKER("UseFreeMarker", BiEventType.MESSAGEML_MESSAGE_SENT),
+  COUNT("Count", BiEventType.NONE);
 
   private final String value;
   private final BiEventType type;


### PR DESCRIPTION
Adding a BiEventType makes a difference at the BiFields level of what is a MESSAGEML_MESSAGE_SENT and MESSAGEML_ELEMENT_SENT.
closes: #271 