### PR TITLE
Avoid Freemarker warning in logs

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -112,7 +112,7 @@ import javax.xml.xpath.XPathFactory;
  */
 public class MessageMLParser {
   private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final Configuration FREEMARKER = new Configuration(Configuration.getVersion());
+  private static final Configuration FREEMARKER = new Configuration(Configuration.VERSION_2_3_30);
   private final IDataProvider dataProvider;
 
   private BiContext biContext;


### PR DESCRIPTION
Freemarker now logs a warning when Configuration.getVersion() is used, a
specific version should be used instead.

See https://freemarker.apache.org/docs/pgui_config_incompatible_improvements.html

Use the current version that we get as a dependency (that what is
returned by getVersion() now).