### PR TITLE
PLAT-10894: Added empty string as attribute of open in dialog

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
@@ -141,7 +141,7 @@ public class Dialog extends Element {
   private Map<String, String> getPresentationMLAttributes() {
     Map<String, String> pmlAttributes = new HashMap<>();
 
-    pmlAttributes.put(OPEN_ATTRIBUTE, null);
+    pmlAttributes.put(OPEN_ATTRIBUTE, "");
     for (Map.Entry<String, String> mmlAttribute : getAttributes().entrySet()) {
       if (mmlAttribute.getKey().equals(ID_ATTR)) {
         pmlAttributes.put(mmlAttribute.getKey(), SHORT_ID.generate() + "-" + mmlAttribute.getValue());

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/DialogTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/DialogTest.java
@@ -299,7 +299,7 @@ public class DialogTest {
     context.parseMessageML(messageMlInput, null, MessageML.MESSAGEML_VERSION);
 
     final String expectedPattern = "^<div data-format=\"PresentationML\" data-version=\"2.0\">"
-        + "<dialog data-width=\"medium\" data-state=\"close\" id=\"\\S+-dialog-id\" open>"
+        + "<dialog data-width=\"medium\" data-state=\"close\" id=\"\\S+-dialog-id\" open=\"\">"
         + "<div class=\"dialog-title\">title</div>"
         + "<div class=\"dialog-body\">body</div>"
         + "<div class=\"dialog-footer\">footer</div>"


### PR DESCRIPTION
`<dialog open>` is valid HTML whereas it is invalid XML, hence the confusion. Replaced that with `<dialog open="">`