### PR TITLE
Update Button Element to support 'cancel' type

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -31,7 +31,7 @@ import static org.symphonyoss.symphony.messageml.elements.FormElement.TYPE_ATTR;
  * following attributes:
  * <ul>
  *    <li>name (required) -> used to identify the button</li>
- *    <li>type -> default "action", specify the type of the button. Allowed values are "action" and "reset"</li>
+ *    <li>type -> default "action", specify the type of the button. Allowed values are "action", "reset" and "cancel"</li>
  *    <li>class -> can be "primary", "secondary", "tertiary" (deprecated: "primary-destructive","secondary-destructive")</li>
  *    <li>title -> description displayed as a hint<l/i>
  * <ul/>
@@ -43,11 +43,12 @@ public class Button extends Element {
 
   public static final String MESSAGEML_TAG = "button";
   public static final String ACTION_TYPE = "action";
+  public static final String CANCEL_TYPE = "cancel";
   public static final String RESET_TYPE = "reset";
 
   private static final Set<String> VALID_CLASSES = new HashSet<>(Arrays.asList("primary", "secondary", "tertiary", "destructive",
       "primary-destructive", "secondary-destructive")); // primary-destructive, secondary-destructive are deprecated
-  private static final Set<String> VALID_TYPES = new HashSet<>(Arrays.asList(ACTION_TYPE, RESET_TYPE));
+  private static final Set<String> VALID_TYPES = new HashSet<>(Arrays.asList(ACTION_TYPE, RESET_TYPE, CANCEL_TYPE));
 
   public Button(Element parent, FormatEnum format) {
     super(parent, MESSAGEML_TAG, format);
@@ -142,11 +143,17 @@ public class Button extends Element {
     String name = getAttribute(NAME_ATTR);
 
     if (!VALID_TYPES.contains(type)) {
-      throw new InvalidInputException("Attribute \"type\" must be \"action\" or \"reset\"");
+      throw new InvalidInputException("Attribute \"type\" must be \"action\", \"reset\" or \"cancel\"");
     }
+
     if (type.equals(ACTION_TYPE) && StringUtils.isBlank(name)) {
       throw new InvalidInputException("Attribute \"name\" is required for action buttons");
     }
+
+    if (type.equals(CANCEL_TYPE) && StringUtils.isBlank(name)) {
+      throw new InvalidInputException("Attribute \"name\" is required for cancel buttons");
+    }
+
     if (type.equals(RESET_TYPE) && getAttributes().containsKey(NAME_ATTR)) {
       throw new InvalidInputException("Attribute \"name\" is allowed for action buttons only");
     }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/DialogTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/DialogTest.java
@@ -23,6 +23,11 @@ public class DialogTest {
 
   private static final String TEXT_FIELD_FORM =
       "<form><text-field name=\"name1\" id=\"id1\" placeholder=\"placeholder1\" required=\"true\" /></form>";
+  private static final String BUTTON_CANCEL_FORM =
+      "<form id=\"form-id\">"
+          + "<button name=\"send-answers\" type=\"action\">Send Answers</button>"
+          + "<button type=\"cancel\" name=\"name\">Cancel</button>"
+          + "</form>";
   private static final String SIMPLE_DIALOG = "<dialog id=\"toto\"><title>e</title><body>f</body></dialog>";
 
   private final IDataProvider dataProvider = new TestDataProvider();
@@ -122,6 +127,14 @@ public class DialogTest {
     context.parseMessageML(messageML, null, MessageML.MESSAGEML_VERSION);
 
     assertDialogBuilt(context.getMessageML(), dialogId, Dialog.MEDIUM_WIDTH, Dialog.CLOSE_STATE, title, body, footer);
+  }
+
+  @Test
+  public void testDialogWithCancelButton() throws Exception {
+    String messageML = buildDialogMML("dialog-id", "title", "body", BUTTON_CANCEL_FORM);
+    context.parseMessageML(messageML, null, MessageML.MESSAGEML_VERSION);
+    assertDialogWithFormBuilt(context.getMessageML(), "dialog-id", Dialog.MEDIUM_WIDTH, Dialog.CLOSE_STATE, "title",
+        "body");
   }
 
   @Test(expected = InvalidInputException.class)
@@ -366,6 +379,21 @@ public class DialogTest {
 
     List<BiItem> biItems = context.getBiContext().getItems();
     assertIterableEquals(expectedBiItems, biItems);
+  }
+
+  private void assertDialogWithFormBuilt(MessageML messageML, String dialogId, String width, String state, String title,
+      String body) {
+    final Element dialog = messageML.getChild(0);
+    final Element dialogTitle = dialog.getChild(0);
+    final Element dialogBody = dialog.getChild(1);
+    final Element dialogFooter = dialog.getChild(2);
+
+    assertTrue(dialog instanceof Dialog);
+    assertTrue(dialogTitle instanceof DialogChild.Title);
+    assertTrue(dialogBody instanceof DialogChild.Body);
+    assertTrue(dialogFooter instanceof DialogChild.Footer);
+
+    assertDialogBuilt(messageML, dialogId, width, state, title, body, dialogFooter.asText());
   }
 
   private void assertDialogBuilt(MessageML messageML, String dialogId, String width, String state, String title,

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
@@ -93,7 +93,7 @@ public class ButtonTest extends ElementTest {
   }
 
   @Test
-  public void testCancelButtonWithoutName() throws Exception {
+  public void testCancelButtonWithoutName() {
     String type = CANCEL_TYPE;
     String innerText = "Cancel Button With Name";
     String input =


### PR DESCRIPTION
This PR is related to #285 
In order to support new dialog element, button should support 'cancel' type. A new type was added to the supported ones. Button's name is set to required for it.