### PR TITLE
MML-291 Add multi-submit attribute to form element

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiFields.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiFields.java
@@ -57,6 +57,7 @@ public enum BiFields {
   TYPE_MASKED_TRUE("masked", BiEventType.MESSAGEML_ELEMENT_SENT),
   TYPE_MASKED_FALSE("normal", BiEventType.MESSAGEML_ELEMENT_SENT),
   ENTITY_TYPE("entity_type", BiEventType.MESSAGEML_ELEMENT_SENT),
+  MULTI_SUBMIT("is_multi_submit", BiEventType.MESSAGEML_ELEMENT_SENT),
   LABEL("has_label", BiEventType.MESSAGEML_ELEMENT_SENT),
   OPTIONS_COUNT("options_count", BiEventType.MESSAGEML_ELEMENT_SENT),
   VALIDATION("validation", BiEventType.MESSAGEML_ELEMENT_SENT),

--- a/src/main/java/org/symphonyoss/symphony/messageml/markdown/nodes/EmojiNode.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/markdown/nodes/EmojiNode.java
@@ -68,7 +68,7 @@ public class EmojiNode extends CustomNode implements Delimited {
    */
   @Deprecated
   public void setAnnotation(String name) {
-    this.annotation = annotation;
+    this.annotation = name;
   }
 
 }


### PR DESCRIPTION
Goal of this PR is to add a new attribute to the form element called "multi-submit". This attribute accepts only two values depending if the user wants to reset or not the previous submit input. More info on this are available here: https://github.com/symphonyoss/messageml-utils/issues/291.
Also a new BI item hs been introduce to track usage of multi-submit forms.

Closes #291 