### PR TITLE
MML-294 Fixing some issued with the UIAction and Dialog elements

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * This class represents the Symphony Element Dialog which is represented with tag name "dialog".
@@ -122,30 +123,21 @@ public class Dialog extends Element {
   }
 
   private void validateChildrenTypes() throws InvalidInputException {
-    if (getChildren().size() > 1 && getChildren().stream().anyMatch(element -> element instanceof Form)){
-      throw new InvalidInputException("A \"dialog\" element can't contain a \"form\" element and any other element.");
-    } else if (getChildren().size() == 1 && getChild(0).getClass().equals(Form.class)) {
-      Element formElement = getChild(0);
-      validateChildren(formElement);
-      validateNoOtherChildrenTypes(formElement, "A \"form\" element in a \"dialog\" element can only contain \"title\", \"body\", \"footer\" elements");
+    long formsCount = getChildren().stream().filter(element -> element instanceof Form).count();
+    if (formsCount == 1) {
+      assertContentModel(Collections.singleton(Form.class),
+          "A \"dialog\" element can't contain a \"form\" element and any other element.");
+    } else if (formsCount > 1) {
+      throw new InvalidInputException("A \"dialog\" element can contain only one \"form\" element");
     } else {
       validateChildren(this);
-      validateNoOtherChildrenTypes(this, "A \"dialog\" can only contain tags \"title\", \"body\", \"footer\"");
+      assertContentModel(Arrays.asList(DialogChild.Footer.class, DialogChild.Title.class, DialogChild.Body.class));
     }
   }
 
   private void validateChildren(Element rootElement) throws InvalidInputException {
     rootElement.assertContainsAlwaysChildOfType(Collections.singleton(DialogChild.Title.class));
     rootElement.assertContainsAlwaysChildOfType(Collections.singleton(DialogChild.Body.class));
-
-  }
-
-  private void validateNoOtherChildrenTypes(Element rootElement, String errorMessage) throws InvalidInputException {
-    final boolean areAllChildrenOfAllowedTypes =
-        rootElement.getChildren().stream().allMatch(element -> element instanceof DialogChild);
-    if (!areAllChildrenOfAllowedTypes) {
-      throw new InvalidInputException(errorMessage);
-    }
   }
 
   private Map<String, String> getPresentationMLAttributes() {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * This class represents the Symphony Element Dialog which is represented with tag name "dialog".
@@ -134,6 +133,7 @@ public class Dialog extends Element {
       assertContentModel(Arrays.asList(DialogChild.Footer.class, DialogChild.Title.class, DialogChild.Body.class));
     }
   }
+
 
   private void validateChildren(Element rootElement) throws InvalidInputException {
     rootElement.assertContainsAlwaysChildOfType(Collections.singleton(DialogChild.Title.class));

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -635,6 +635,18 @@ public abstract class Element {
   }
 
   /**
+   * Check that the element's children are limited to allowed element types returning a specific message given in input.
+   */
+  void assertContentModel(Collection<Class<? extends Element>> permittedChildren, String message)
+      throws InvalidInputException {
+    try {
+      assertContentModel(permittedChildren);
+    } catch (InvalidInputException e) {
+      throw new InvalidInputException(message);
+    }
+  }
+
+  /**
    * Check that the element's children are limited to allowed element types.
    */
   void assertContentModel(Collection<Class<? extends Element>> permittedChildren) throws InvalidInputException {
@@ -768,6 +780,23 @@ public abstract class Element {
               getElementNameByClass(this.getClass()), maxCountPerElementType,
               getElementsNameByClassName(elementTypes)));
     }
+  }
+
+  /**
+   * Given a target id present in a UIAction this method returns the corresponding dialog associated to the same
+   * id, if no dialog is found it throws an exception
+   */
+  Dialog checkMatchingDialog(String targetId) throws InvalidInputException {
+    final List<Element> matchingDialogs = this.getChildren()
+        .stream()
+        .filter(e -> e instanceof Dialog && targetId.equals(e.getAttribute(ID_ATTR)))
+        .collect(Collectors.toList());
+
+    if (matchingDialogs.size() != 1) {
+      throw new InvalidInputException(
+          "ui-action with a target-id must have only one dialog sibling with a matching id");
+    }
+    return (Dialog) matchingDialogs.get(0);
   }
 
   /**

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -889,21 +890,21 @@ public abstract class Element {
   /**
    * Search the MessageML tree (depth-first) for elements of a given type.
    *
-   * @param type the class of elements to find
+   * @param predicate discriminator to match the element
    * @return found elements
    */
-  public List<Element> findElements(Class<?> type) {
+   List<Element> findElements(Predicate<Element> predicate) {
     List<Element> result = new ArrayList<>();
     LinkedList<Element> stack = new LinkedList<>(this.getChildren());
 
-    if (this.getClass() == type) {
+    if (predicate.test(this)) {
       result.add(this);
     }
 
     while (!stack.isEmpty()) {
       Element child = stack.pop();
       stack.addAll(0, child.getChildren());
-      if (child.getClass() == type) {
+      if (predicate.test(child)) {
         result.add(child);
       }
     }
@@ -911,32 +912,14 @@ public abstract class Element {
     return result;
   }
 
-
   /**
-   * Search the MessageML tree (depth-first) for elements of a given type that contains a specific
-   * attribute.
+   * Search the MessageML tree (depth-first) for elements of a given type.
    *
    * @param type the class of elements to find
-   * @param attribute the attribute that the element must contain
    * @return found elements
    */
-  public List<Element> findElementsWithAttribute(Class<?> type, String attribute) {
-    List<Element> result = new ArrayList<>();
-    LinkedList<Element> stack = new LinkedList<>(this.getChildren());
-
-    if (this.getClass() == type) {
-      result.add(this);
-    }
-
-    while (!stack.isEmpty()) {
-      Element child = stack.pop();
-      stack.addAll(0, child.getChildren());
-      if (child.getClass() == type && child.getAttribute(attribute) != null) {
-        result.add(child);
-      }
-    }
-
-    return result;
+  public List<Element> findElements(Class<?> type) {
+    return findElements(element -> element.getClass() == type);
   }
 
   /**
@@ -946,22 +929,7 @@ public abstract class Element {
    * @return found elements
    */
   public List<Element> findElements(String tag) {
-    List<Element> result = new ArrayList<>();
-    LinkedList<Element> stack = new LinkedList<>(this.getChildren());
-
-    if (tag.equalsIgnoreCase(this.getMessageMLTag())) {
-      result.add(this);
-    }
-
-    while (!stack.isEmpty()) {
-      Element child = stack.pop();
-      stack.addAll(0, child.getChildren());
-      if (tag.equalsIgnoreCase(child.getMessageMLTag())) {
-        result.add(child);
-      }
-    }
-
-    return result;
+    return findElements(element -> tag.equalsIgnoreCase(element.getMessageMLTag()));
   }
 
   /**
@@ -972,23 +940,7 @@ public abstract class Element {
    * @return found elements
    */
   public List<Element> findElements(String attribute, String value) {
-    List<Element> result = new ArrayList<>();
-    LinkedList<Element> stack = new LinkedList<>(this.getChildren());
-
-    if (value.equals(getAttribute(attribute))) {
-      result.add(this);
-    }
-
-    while (!stack.isEmpty()) {
-      Element child = stack.pop();
-      stack.addAll(0, child.getChildren());
-
-      if (value.equals(child.getAttribute(attribute))) {
-        result.add(child);
-      }
-    }
-
-    return result;
+    return findElements(element -> value.equals(element.getAttribute(attribute)));
   }
 
   public Integer countNonTextNodesInNodeList(NodeList nodeList) {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Form.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Form.java
@@ -56,6 +56,8 @@ public class Form extends Element {
     assertAttributeNotBlank(ID_ATTR);
     if (!getParent().getClass().equals(Dialog.class)) {
       assertAtLeastOneActionButton();
+    } else {
+      assertContentModel(Arrays.asList(DialogChild.Footer.class, DialogChild.Title.class, DialogChild.Body.class));
     }
     if(getAttribute(MULTI_SUBMIT) != null) {
       assertAttributeMaxLength(MULTI_SUBMIT, MAX_LENGTH);

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/MessageML.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/MessageML.java
@@ -167,12 +167,9 @@ public class MessageML extends Element {
    * dialog element with the same id.
    */
   private void validateTargetIdForUIActions() throws InvalidInputException {
-    List<Element> uiActionWithTargetId = getChildren().stream()
-        .filter(element -> element instanceof UIAction && element.getAttribute(TARGET_ID) != null)
-        .collect(
-            Collectors.toList());
+    List<Element> uiActionWithTargetId = findElementsWithAttribute(UIAction.class, TARGET_ID);
     for(Element uiAction: uiActionWithTargetId) {
-      Dialog dialog = checkMatchingDialog(uiAction.getAttribute(TARGET_ID));
+      Dialog dialog = findMatchingDialog((UIAction) uiAction);
       uiAction.setAttribute(TARGET_ID, dialog.getPresentationMlIdAttribute());
     }
   }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/MessageML.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/MessageML.java
@@ -167,7 +167,8 @@ public class MessageML extends Element {
    * dialog element with the same id.
    */
   private void validateTargetIdForUIActions() throws InvalidInputException {
-    List<Element> uiActionWithTargetId = findElementsWithAttribute(UIAction.class, TARGET_ID);
+    List<Element> uiActionWithTargetId =
+        findElements(element -> element.getClass() == UIAction.class && element.getAttribute(TARGET_ID) != null);
     for(Element uiAction: uiActionWithTargetId) {
       Dialog dialog = findMatchingDialog((UIAction) uiAction);
       uiAction.setAttribute(TARGET_ID, dialog.getPresentationMlIdAttribute());

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/MessageML.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/MessageML.java
@@ -31,6 +31,11 @@ import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 import org.w3c.dom.Node;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.symphonyoss.symphony.messageml.elements.UIAction.TARGET_ID;
+
 
 /**
  * Class representing a MessageML document (i.e. a message).
@@ -134,6 +139,7 @@ public class MessageML extends Element {
       }
 
     }
+    validateTargetIdForUIActions();
   }
 
   /**
@@ -154,5 +160,20 @@ public class MessageML extends Element {
   @Override
   public String getPresentationMLTag() {
     return PRESENTATIONML_TAG;
+  }
+
+  /**
+   * If the messageML contains a uiAction with a target-id this method checks that exists a corresponding
+   * dialog element with the same id.
+   */
+  private void validateTargetIdForUIActions() throws InvalidInputException {
+    List<Element> uiActionWithTargetId = getChildren().stream()
+        .filter(element -> element instanceof UIAction && element.getAttribute(TARGET_ID) != null)
+        .collect(
+            Collectors.toList());
+    for(Element uiAction: uiActionWithTargetId) {
+      Dialog dialog = checkMatchingDialog(uiAction.getAttribute(TARGET_ID));
+      uiAction.setAttribute(TARGET_ID, dialog.getPresentationMlIdAttribute());
+    }
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/UIAction.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/UIAction.java
@@ -13,7 +13,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * This class specify the Symphony Component UIAction which is represented by the tag name "ui-action".
@@ -41,7 +40,7 @@ public class UIAction extends Element {
   private static final String USER_IDS_ATTR = "user-ids";
   private static final String STREAM_ID_ATTR = "stream-id";
   private static final String SIDE_BY_SIDE_ATTR = "side-by-side";
-  private static final String TARGET_ID = "target-id";
+  public static final String TARGET_ID = "target-id";
 
   private static final String DEFAULT_TRIGGER = "click";
   private static final String OPEN_IM = "open-im";
@@ -55,8 +54,7 @@ public class UIAction extends Element {
   private static final String PRESENTATIONML_USER_IDS_ATTR = "data-user-ids";
   private static final String PRESENTATIONML_STREAM_ID_ATTR = "data-stream-id";
   private static final String PRESENTATIONML_SIDE_BY_SIDE_ATTR = "data-side-by-side";
-
-  private Dialog matchingDialog;
+  private static final String DATA_TARGET_ID = "data-target-id";
 
   public UIAction(Element parent, FormatEnum format) {
     super(parent, MESSAGEML_TAG, format);
@@ -93,30 +91,12 @@ public class UIAction extends Element {
     if (actionAttribute.equals(OPEN_IM)) {
       validateOpenChatActionAttributes();
     } else if (actionAttribute.equals(OPEN_DIALOG)) {
-      validateTargetId(getAttribute(TARGET_ID));
+      validateIdAttribute(TARGET_ID);
     }
 
     if (getAttribute(TRIGGER_ATTR) != null) {
       assertAttributeValue(TRIGGER_ATTR, Collections.singleton(DEFAULT_TRIGGER));
     }
-  }
-
-  private void validateTargetId(String targetId) throws InvalidInputException {
-    validateIdAttribute(TARGET_ID);
-    checkMatchingDialog(targetId);
-  }
-
-  private void checkMatchingDialog(String targetId) throws InvalidInputException {
-    final List<Element> matchingDialogs = getParent().getChildren()
-        .stream()
-        .filter(e -> e instanceof Dialog && targetId.equals(e.getAttribute(ID_ATTR)))
-        .collect(Collectors.toList());
-
-    if (matchingDialogs.size() != 1) {
-      throw new InvalidInputException(
-          "ui-action with a target-id must have only one dialog sibling with a matching id");
-    }
-    matchingDialog = (Dialog) matchingDialogs.get(0);
   }
 
   private void validateOpenChatActionAttributes() throws InvalidInputException {
@@ -206,7 +186,7 @@ public class UIAction extends Element {
       presentationAttrs.put(PRESENTATIONML_SIDE_BY_SIDE_ATTR, getAttribute(SIDE_BY_SIDE_ATTR));
     }
     if (getAttribute(TARGET_ID) != null) {
-      presentationAttrs.put("data-target-id", matchingDialog.getPresentationMlIdAttribute());
+      presentationAttrs.put(DATA_TARGET_ID, getAttribute(TARGET_ID));
     }
 
     return presentationAttrs;

--- a/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextBenchmark.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextBenchmark.java
@@ -2,6 +2,10 @@ package org.symphonyoss.symphony.messageml;
 
 import org.apache.commons.io.IOUtils;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
@@ -12,6 +16,21 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 public class MessageMLContextBenchmark {
+
+  @State(Scope.Thread)
+  public static class MessageContent {
+    public String messageML;
+    public String entityJson;
+
+    @Setup(Level.Trial)
+    public void doSetup() throws IOException {
+      FileInputStream messageFile =
+          new FileInputStream("src/test/resources/payloads/complex_message_with_styles.messageml");
+      messageML = IOUtils.toString(messageFile, StandardCharsets.UTF_8);
+      FileInputStream entityFile = new FileInputStream("src/test/resources/payloads/complex_message_with_styles.json");
+      entityJson = IOUtils.toString(entityFile, StandardCharsets.UTF_8);
+    }
+  }
 
   @Benchmark
   public void parseSimpleMessageML(Blackhole bh) throws InvalidInputException, ProcessingException, IOException {
@@ -24,15 +43,10 @@ public class MessageMLContextBenchmark {
   }
 
   @Benchmark
-  public void parseComplexMessageMLWithEntities(Blackhole bh) throws InvalidInputException, ProcessingException, IOException {
+  public void parseComplexMessageMLWithEntities(MessageContent messageContent, Blackhole bh)
+      throws InvalidInputException, ProcessingException, IOException {
     MessageMLContext messageMLContext = new MessageMLContext(new NoOpDataProvider());
-
-    FileInputStream messageFile =
-        new FileInputStream("src/test/resources/payloads/complex_message_with_styles.messageml");
-    String messageML = IOUtils.toString(messageFile, StandardCharsets.UTF_8);
-    FileInputStream entityFile = new FileInputStream("src/test/resources/payloads/complex_message_with_styles.json");
-    String entityJson = IOUtils.toString(entityFile, StandardCharsets.UTF_8);
-    messageMLContext.parseMessageML(messageML, entityJson, null);
+    messageMLContext.parseMessageML(messageContent.messageML, messageContent.entityJson, null);
 
     // those calls are usually made by the agent when sending a message
     bh.consume(messageMLContext.getText());

--- a/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextBenchmark.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextBenchmark.java
@@ -1,12 +1,15 @@
 package org.symphonyoss.symphony.messageml;
 
+import org.apache.commons.io.IOUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.infra.Blackhole;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.exceptions.ProcessingException;
 import org.symphonyoss.symphony.messageml.util.NoOpDataProvider;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class MessageMLContextBenchmark {
 
@@ -14,6 +17,22 @@ public class MessageMLContextBenchmark {
   public void parseSimpleMessageML(Blackhole bh) throws InvalidInputException, ProcessingException, IOException {
     MessageMLContext messageMLContext = new MessageMLContext(new NoOpDataProvider());
     messageMLContext.parseMessageML("<messageML>Hello</messageML>", "", null);
+
+    // those calls are usually made by the agent when sending a message
+    bh.consume(messageMLContext.getText());
+    bh.consume(messageMLContext.getPresentationML());
+  }
+
+  @Benchmark
+  public void parseComplexMessageMLWithEntities(Blackhole bh) throws InvalidInputException, ProcessingException, IOException {
+    MessageMLContext messageMLContext = new MessageMLContext(new NoOpDataProvider());
+
+    FileInputStream messageFile =
+        new FileInputStream("src/test/resources/payloads/complex_message_with_styles.messageml");
+    String messageML = IOUtils.toString(messageFile, StandardCharsets.UTF_8);
+    FileInputStream entityFile = new FileInputStream("src/test/resources/payloads/complex_message_with_styles.json");
+    String entityJson = IOUtils.toString(entityFile, StandardCharsets.UTF_8);
+    messageMLContext.parseMessageML(messageML, entityJson, null);
 
     // those calls are usually made by the agent when sending a message
     bh.consume(messageMLContext.getText());

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/UIActionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/UIActionTest.java
@@ -428,13 +428,40 @@ public class UIActionTest extends ElementTest {
             + "<ui-action trigger=\"click\" action=\"open-dialog\" target-id=\"target-dialog-id\">"
             + "<button>Open the dialog</button>"
             + "</ui-action>"
+            + "<button type=\"action\" name=\"send-form\">Submit</button>"
             + "</form>"
             + "</messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("The form with id 'form-id' should have at least one action button");
+    expectedException.expectMessage("ui-action with a target-id must have only one dialog sibling with a matching id");
 
     context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testUIActionOpenDialogNested() throws Exception {
+    String inputMessageML =
+        "<messageML>"
+            + "<form id=\"form-id\">"
+            + "<ui-action trigger=\"click\" action=\"open-dialog\" target-id=\"target-dialog-id\">"
+            + "<button>Open the dialog</button>"
+            + "</ui-action>"
+            + "<dialog id=\"target-dialog-id\">"
+            + "<title>title</title>"
+            + "<body>body</body>"
+            + "</dialog>"
+            + "<button type=\"action\" name=\"send-form\">Submit</button>"
+            + "</form>"
+            + "</messageML>";
+    String expectedPattern = "<div data-format=\"PresentationML\" data-version=\"2.0\">"
+        + "<form id=\"form-id\">"
+        + "<div class=\"ui-action\" data-action=\"open-dialog\" data-trigger=\"click\" data-target-id=\"\\S+-target-dialog-id\">"
+        + "<button>Open the dialog</button></div>"
+        + "<dialog data-width=\"medium\" data-state=\"close\" id=\"\\S+-target-dialog-id\" open=\"\">"
+        + "<div class=\"dialog-title\">title</div><div class=\"dialog-body\">body</div></dialog>"
+        + "<button type=\"action\" name=\"send-form\">Submit</button></form></div>";
+    context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
+    assertTrue(context.getPresentationML().matches(expectedPattern));
   }
 
   @Test

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/UIActionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/UIActionTest.java
@@ -338,6 +338,85 @@ public class UIActionTest extends ElementTest {
   }
 
   @Test
+  public void testTargetIdWhenUIActionComesFirst() throws InvalidInputException, IOException, ProcessingException {
+    String input = "<messageML>"
+        + "<ui-action trigger=\"click\" action=\"open-dialog\" target-id=\"dialogId\">"
+        + "<button>Open the Dialog</button>"
+        + "</ui-action>"
+        + "<dialog id=\"dialogId\">"
+        + "<form id=\"all-elements\">"
+        + "<title>My Form in a Dialog</title>"
+        + "<body>"
+        + "<text-field name=\"name\" placeholder=\"Input your name...\"/>"
+        + "</body>"
+        + "<footer>"
+        + "<button type=\"action\" name=\"send-form\">Submit</button>"
+        + "<button type=\"reset\">Reset Data</button>"
+        + "<button type=\"cancel\" name=\"cancel-form\">Close</button>"
+        + "</footer>"
+        + "</form>"
+        + "</dialog>"
+        + "</messageML>";
+    String expectedRegex = "<div data-format=\"PresentationML\" data-version=\"2.0\">"
+        + "<div class=\"ui-action\" data-action=\"open-dialog\" data-trigger=\"click\" data-target-id=\"(\\S+)-dialogId\">"
+        + "<button>Open the Dialog</button>"
+        + "</div>"
+        + "<dialog data-width=\"medium\" data-state=\"close\" id=\"(\\S+)-dialogId\" open=\"\">"
+        + "<form id=\"all-elements\">"
+        + "<div class=\"dialog-title\">My Form in a Dialog</div>"
+        + "<div class=\"dialog-body\"><input type=\"text\" name=\"name\" placeholder=\"Input your name...\"/></div>"
+        + "<div class=\"dialog-footer\">"
+        + "<button type=\"action\" name=\"send-form\">Submit</button>"
+        + "<button type=\"reset\">Reset Data</button>"
+        + "<button type=\"cancel\" name=\"cancel-form\">Close</button>"
+        + "</div>"
+        + "</form>"
+        + "</dialog>"
+        + "</div>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    Pattern expectedPattern = Pattern.compile(expectedRegex);
+    Matcher m = expectedPattern.matcher(context.getPresentationML());
+
+    assertTrue(m.find());
+    assertEquals(m.group(1), m.group(2));
+  }
+
+  @Test
+  public void testTargetIdMutipleDialogId() throws InvalidInputException, IOException, ProcessingException {
+    String input = "<messageML>"
+        + "<ui-action trigger=\"click\" action=\"open-dialog\" target-id=\"dialogId\">"
+        + "<button>Open the Dialog</button>"
+        + "</ui-action>"
+        + "<dialog id=\"dialogId\">"
+        + "<form id=\"all-elements\">"
+        + "<title>My Form in a Dialog</title>"
+        + "<body>"
+        + "<text-field name=\"name\" placeholder=\"Input your name...\"/>"
+        + "</body>"
+        + "<footer>"
+        + "<button type=\"action\" name=\"send-form\">Submit</button>"
+        + "</footer>"
+        + "</form>"
+        + "</dialog>"
+        + "<dialog id=\"dialogId\">"
+        + "<form id=\"all-elements1\">"
+        + "<title>My Form in a Dialog</title>"
+        + "<body>"
+        + "<text-field name=\"name\" placeholder=\"Input your name...\"/>"
+        + "</body>"
+        + "<footer>"
+        + "<button type=\"action\" name=\"send-form\">Submit</button>"
+        + "</footer>"
+        + "</form>"
+        + "</dialog>"
+        + "</messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Elements must have unique ids. The following value is not unique: [dialogId].");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testUIActionOpenDialogInDifferentScopeFromDialog() throws Exception {
     String inputMessageML =
         "<messageML>"
@@ -345,7 +424,7 @@ public class UIActionTest extends ElementTest {
             + "<title>title</title>"
             + "<body>body</body>"
             + "</dialog>"
-            + "<form>"
+            + "<form id=\"form-id\">"
             + "<ui-action trigger=\"click\" action=\"open-dialog\" target-id=\"target-dialog-id\">"
             + "<button>Open the dialog</button>"
             + "</ui-action>"
@@ -353,7 +432,7 @@ public class UIActionTest extends ElementTest {
             + "</messageML>";
 
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("ui-action with a target-id must have only one dialog sibling with a matching id");
+    expectedException.expectMessage("The form with id 'form-id' should have at least one action button");
 
     context.parseMessageML(inputMessageML, null, MessageML.MESSAGEML_VERSION);
   }


### PR DESCRIPTION
Goal of this PR is to fix some minor issues found during validation.
- Allowing the presence of whitespaces inside the Dialog element
- If a UIAction with a target-id referring to a Dialog comes in the messageML before the Dialog itself, the message should be allowed and parsed correctly.
- No more that one form is allowed inside a Dialog element
- We should be able to match Dialog-UIAction target id even if they are nested inside another element.
- Matching Dialog-UiAction should be in the same scope (at the same level of the messageML tree) to be valid.

Closes #295 