### PR TITLE
MML-298 Fix XXE in json-schema-validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -117,6 +118,7 @@
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <freemarker.version>2.3.31</freemarker.version>
         <commonmark.version>0.15.1</commonmark.version>
+        <mozilla.rhino.version>1.7.12</mozilla.rhino.version>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.params.version>5.7.1</junit.jupiter.params.version>
         <mockito.version>3.11.2</mockito.version>
@@ -246,6 +248,17 @@
             <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>${json.schema.validator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mozilla</groupId>
+                    <artifactId>rhino</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.mozilla</groupId>
+            <artifactId>rhino</artifactId>
+            <version>${mozilla.rhino.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
```
  ✗ XML External Entity (XXE) Injection [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295] in org.mozilla:rhino@1.7.7.1
    introduced by org.symphonyoss.symphony:messageml@0.9.70 > com.github.java-json-tools:json-schema-validator@2.2.10 > com.github.java-json-tools:json-schema-core@1.2.10 > org.mozilla:rhino@1.7.7.1
  This issue was fixed in versions: 1.7.12
```

Latest available `json-schema-validator` (2.2.14, released May 2020) ships with an unsafe Rhino version. Need to add an exclusion and pull in a safe Rhino version explicitly.