### PR TITLE
feat: move beta mode to constructor and rename AI elements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.finos.symphony.messageml</groupId>
     <artifactId>messageml-utils</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <name>MessageML Utils</name>
     <url>https://github.com/finos/messageml-utils</url>
     <description>A set of utilities for parsing, processing and rendering of MessageML messages

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/MessageMLContext.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/MessageMLContext.java
@@ -49,6 +49,7 @@ public class MessageMLContext {
   private final MessageMLParser messageMLParser;
   private final MarkdownParser markdownParser;
   private final ShortID shortID;
+  private final boolean beta;
 
   private MarkdownRenderer markdownRenderer;
   private MessageML messageML;
@@ -57,10 +58,15 @@ public class MessageMLContext {
   private String presentationML;
 
   public MessageMLContext(IDataProvider dataProvider) {
+    this(dataProvider, false);
+  }
+
+  public MessageMLContext(IDataProvider dataProvider, boolean beta) {
     this.markdownParser = new MarkdownParser(dataProvider);
-    this.messageMLParser = new MessageMLParser(dataProvider);
+    this.messageMLParser = new MessageMLParser(dataProvider, beta);
     this.shortID = new ShortID();
     this.biContext = new BiContext();
+    this.beta = beta;
   }
 
   /**

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/MessageMLParser.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/MessageMLParser.java
@@ -148,6 +148,7 @@ public class MessageMLParser {
   });
 
   private final IDataProvider dataProvider;
+  private final boolean beta;
 
   private BiContext biContext;
   private FormatEnum messageFormat;
@@ -167,7 +168,12 @@ public class MessageMLParser {
   }
 
   MessageMLParser(IDataProvider dataProvider) {
+    this(dataProvider, false);
+  }
+
+  MessageMLParser(IDataProvider dataProvider, boolean beta) {
     this.dataProvider = dataProvider;
+    this.beta = beta;
   }
 
   /**
@@ -372,6 +378,7 @@ public class MessageMLParser {
     }
 
     MessageML result = new MessageML(messageFormat, version);
+    result.setBeta(beta);
     result.buildAll(this, docElement);
     result.enhanceFinancialTags(result, dataProvider);
     result.validate();

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/MessageMLParser.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/MessageMLParser.java
@@ -378,8 +378,14 @@ public class MessageMLParser {
     }
 
     MessageML result = new MessageML(messageFormat, version);
-    result.setBeta(beta);
     result.buildAll(this, docElement);
+
+    // Validate that beta attribute on messageML is only allowed when context permits it
+    if (result.isBeta() && !beta) {
+      throw new InvalidInputException(
+          "Attribute \"beta\" on element \"messageML\" is only allowed when MessageMLContext is initialized with beta=true");
+    }
+
     result.enhanceFinancialTags(result, dataProvider);
     result.validate();
     return result;

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/Attachment.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/Attachment.java
@@ -8,7 +8,7 @@ import org.finos.symphony.messageml.messagemlutils.exceptions.InvalidInputExcept
 import org.commonmark.node.Node;
 
 public class Attachment extends Element {
-    public static final String MESSAGEML_TAG = "attachment";
+    public static final String MESSAGEML_TAG = "sym-ai-attachment";
     private static final String ATTR_STREAM_ID = "streamId";
     private static final String ATTR_MESSAGE_ID = "messageId";
     private static final String ATTR_FILE_ID = "fileId";

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/Message.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/Message.java
@@ -6,7 +6,7 @@ import org.finos.symphony.messageml.messagemlutils.exceptions.InvalidInputExcept
 import org.commonmark.node.Node;
 
 public class Message extends Element {
-    public static final String MESSAGEML_TAG = "message";
+    public static final String MESSAGEML_TAG = "sym-ai-message";
     private static final String ATTR_ID = "id";
 
     public Message(Element parent) {
@@ -28,7 +28,7 @@ public class Message extends Element {
     public void validate() throws InvalidInputException {
         assertNoContent();
         if (getAttribute(ATTR_ID) == null) {
-            throw new InvalidInputException("The attribute 'id' is required for the element 'message'.");
+            throw new InvalidInputException("The attribute 'id' is required for the element 'sym-ai-message'.");
         }
     }
 

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/MessageML.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/MessageML.java
@@ -63,7 +63,6 @@ public class MessageML extends Element {
   private static final String ATTR_FORMAT = "data-format";
   private static final String ATTR_VERSION = "data-version";
   private static final String ATTR_XMLNS = "xmlns";
-  private static final String ATTR_BETA = "beta";
   private static final String PRESENTATIONML_FORMAT = "PresentationML";
 
   private String version;
@@ -95,15 +94,6 @@ public class MessageML extends Element {
       switch (item.getNodeName()) {
         case ATTR_XMLNS:
           this.xmlns = getStringAttribute(item);
-          break;
-
-        case ATTR_BETA:
-          String betaValue = getStringAttribute(item);
-          if (!"true".equals(betaValue) && !"false".equals(betaValue)) {
-            throw new InvalidInputException(
-                "Attribute \"beta\" of element \"messageML\" can only be one of the following values: [true, false].");
-          }
-          this.beta = Boolean.parseBoolean(betaValue);
           break;
 
         default:
@@ -191,6 +181,13 @@ public class MessageML extends Element {
    */
   public boolean isBeta() {
     return beta;
+  }
+
+  /**
+   * Set whether this message is a beta message.
+   */
+  public void setBeta(boolean beta) {
+    this.beta = beta;
   }
 
   @Override

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/MessageML.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/MessageML.java
@@ -63,6 +63,7 @@ public class MessageML extends Element {
   private static final String ATTR_FORMAT = "data-format";
   private static final String ATTR_VERSION = "data-version";
   private static final String ATTR_XMLNS = "xmlns";
+  private static final String ATTR_BETA = "beta";
   private static final String PRESENTATIONML_FORMAT = "PresentationML";
 
   private String version;
@@ -94,6 +95,15 @@ public class MessageML extends Element {
       switch (item.getNodeName()) {
         case ATTR_XMLNS:
           this.xmlns = getStringAttribute(item);
+          break;
+
+        case ATTR_BETA:
+          String betaValue = getStringAttribute(item);
+          if (!"true".equals(betaValue) && !"false".equals(betaValue)) {
+            throw new InvalidInputException(
+                "Attribute \"beta\" of element \"messageML\" can only be one of the following values: [true, false].");
+          }
+          this.beta = Boolean.parseBoolean(betaValue);
           break;
 
         default:

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/Stream.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/Stream.java
@@ -6,7 +6,7 @@ import org.finos.symphony.messageml.messagemlutils.exceptions.InvalidInputExcept
 import org.commonmark.node.Node;
 
 public class Stream extends Element {
-    public static final String MESSAGEML_TAG = "stream";
+    public static final String MESSAGEML_TAG = "sym-ai-stream";
     private static final String ATTR_ID = "id";
 
     public Stream(Element parent) {
@@ -28,7 +28,7 @@ public class Stream extends Element {
     public void validate() throws InvalidInputException {
         assertNoContent();
         if (getAttribute(ATTR_ID) == null) {
-            throw new InvalidInputException("The attribute 'id' is required for the element 'stream'.");
+            throw new InvalidInputException("The attribute 'id' is required for the element 'sym-ai-stream'.");
         }
     }
 

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/SymAiContext.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/SymAiContext.java
@@ -32,7 +32,7 @@ public class SymAiContext extends Entity {
         MessageML root = getRoot();
         if (root == null || !root.isBeta()) {
             throw new InvalidInputException(
-                    "Element \"sym-ai-context\" is only allowed when messageML has beta=\"true\"");
+                    "Element \"sym-ai-context\" is only allowed when MessageMLContext is initialized with beta=true");
         }
 
         super.validate();

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/SymAiContext.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/elements/SymAiContext.java
@@ -28,11 +28,11 @@ public class SymAiContext extends Entity {
 
     @Override
     public void validate() throws InvalidInputException {
-        // Check if root MessageML is in beta mode
+        // Check if root MessageML has beta="true"
         MessageML root = getRoot();
         if (root == null || !root.isBeta()) {
             throw new InvalidInputException(
-                    "Element \"sym-ai-context\" is only allowed when MessageMLContext is initialized with beta=true");
+                    "Element \"sym-ai-context\" is only allowed when messageML has beta=\"true\"");
         }
 
         super.validate();

--- a/src/test/java/org/finos/symphony/messageml/messagemlutils/elements/ElementTest.java
+++ b/src/test/java/org/finos/symphony/messageml/messagemlutils/elements/ElementTest.java
@@ -106,9 +106,9 @@ public class ElementTest {
 
   @Test
   public void testMessageMLBetaTrue() throws Exception {
-    // Create context with beta=true
+    // Create context with beta=true and use beta="true" attribute
     MessageMLContext betaContext = new MessageMLContext(dataProvider, true);
-    String input = "<messageML>Hello world!</messageML>";
+    String input = "<messageML beta=\"true\">Hello world!</messageML>";
     betaContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
 
     MessageML messageML = betaContext.getMessageML();
@@ -119,26 +119,45 @@ public class ElementTest {
 
   @Test
   public void testMessageMLBetaFalse() throws Exception {
-    // Create context with beta=false explicitly
-    MessageMLContext nonBetaContext = new MessageMLContext(dataProvider, false);
-    String input = "<messageML>Hello world!</messageML>";
-    nonBetaContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    // Create context with beta=true but use beta="false" attribute
+    MessageMLContext betaContext = new MessageMLContext(dataProvider, true);
+    String input = "<messageML beta=\"false\">Hello world!</messageML>";
+    betaContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
 
-    MessageML messageML = nonBetaContext.getMessageML();
+    MessageML messageML = betaContext.getMessageML();
     assertFalse("Beta should be false", messageML.isBeta());
     assertEquals("PresentationML", "<div data-format=\"PresentationML\" data-version=\"2.0\">Hello world!</div>",
-        nonBetaContext.getPresentationML());
+        betaContext.getPresentationML());
   }
 
   @Test
   public void testMessageMLBetaDefault() throws Exception {
-    // Default constructor should have beta=false
+    // Default constructor should have beta=false, and without beta attribute it stays false
     MessageMLContext defaultContext = new MessageMLContext(dataProvider);
     String input = "<messageML>Hello world!</messageML>";
     defaultContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
 
     MessageML messageML = defaultContext.getMessageML();
     assertFalse("Beta should default to false", messageML.isBeta());
+  }
+
+  @Test
+  public void testMessageMLBetaInvalid() throws Exception {
+    MessageMLContext betaContext = new MessageMLContext(dataProvider, true);
+    String input = "<messageML beta=\"invalid\">Hello world!</messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"beta\" of element \"messageML\" can only be one of the following values: [true, false].");
+    betaContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testMessageMLBetaNotAllowedWithoutBetaContext() throws Exception {
+    // Default context (beta=false) should not allow beta="true" attribute
+    MessageMLContext nonBetaContext = new MessageMLContext(dataProvider);
+    String input = "<messageML beta=\"true\">Hello world!</messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"beta\" on element \"messageML\" is only allowed when MessageMLContext is initialized with beta=true");
+    nonBetaContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
 
   @Test

--- a/src/test/java/org/finos/symphony/messageml/messagemlutils/elements/ElementTest.java
+++ b/src/test/java/org/finos/symphony/messageml/messagemlutils/elements/ElementTest.java
@@ -106,41 +106,39 @@ public class ElementTest {
 
   @Test
   public void testMessageMLBetaTrue() throws Exception {
-    String input = "<messageML beta=\"true\">Hello world!</messageML>";
-    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    // Create context with beta=true
+    MessageMLContext betaContext = new MessageMLContext(dataProvider, true);
+    String input = "<messageML>Hello world!</messageML>";
+    betaContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
 
-    MessageML messageML = context.getMessageML();
+    MessageML messageML = betaContext.getMessageML();
     assertTrue("Beta should be true", messageML.isBeta());
     assertEquals("PresentationML", "<div data-format=\"PresentationML\" data-version=\"2.0\">Hello world!</div>",
-        context.getPresentationML());
+        betaContext.getPresentationML());
   }
 
   @Test
   public void testMessageMLBetaFalse() throws Exception {
-    String input = "<messageML beta=\"false\">Hello world!</messageML>";
-    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    // Create context with beta=false explicitly
+    MessageMLContext nonBetaContext = new MessageMLContext(dataProvider, false);
+    String input = "<messageML>Hello world!</messageML>";
+    nonBetaContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
 
-    MessageML messageML = context.getMessageML();
+    MessageML messageML = nonBetaContext.getMessageML();
     assertFalse("Beta should be false", messageML.isBeta());
     assertEquals("PresentationML", "<div data-format=\"PresentationML\" data-version=\"2.0\">Hello world!</div>",
-        context.getPresentationML());
+        nonBetaContext.getPresentationML());
   }
 
   @Test
   public void testMessageMLBetaDefault() throws Exception {
+    // Default constructor should have beta=false
+    MessageMLContext defaultContext = new MessageMLContext(dataProvider);
     String input = "<messageML>Hello world!</messageML>";
-    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    defaultContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
 
-    MessageML messageML = context.getMessageML();
+    MessageML messageML = defaultContext.getMessageML();
     assertFalse("Beta should default to false", messageML.isBeta());
-  }
-
-  @Test
-  public void testMessageMLBetaInvalid() throws Exception {
-    String input = "<messageML beta=\"invalid\">Hello world!</messageML>";
-    expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("Attribute \"beta\" of element \"messageML\" can only be one of the following values: [true, false].");
-    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
 
   @Test

--- a/src/test/java/org/finos/symphony/messageml/messagemlutils/elements/SymAiContextTest.java
+++ b/src/test/java/org/finos/symphony/messageml/messagemlutils/elements/SymAiContextTest.java
@@ -1,25 +1,33 @@
 package org.finos.symphony.messageml.messagemlutils.elements;
 
+import org.finos.symphony.messageml.messagemlutils.MessageMLContext;
 import org.finos.symphony.messageml.messagemlutils.exceptions.InvalidInputException;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 public class SymAiContextTest extends ElementTest {
 
+    @Before
+    @Override
+    public void setUp() {
+        context = new MessageMLContext(dataProvider, true);
+    }
+
     @Test
     public void testSymAiContextWithInvalidChild() {
-        String invalidChild = "<messageML beta=\"true\"><sym-ai-context><p>invalid child</p></sym-ai-context></messageML>";
+        String invalidChild = "<messageML><sym-ai-context><p>invalid child</p></sym-ai-context></messageML>";
 
         Exception exception = assertThrows(InvalidInputException.class, () -> context.parseMessageML(invalidChild, null, null));
-        String expectedMessage = "Element 'p' is not allowed in 'sym-ai-context'. Allowed elements are: [stream, message, attachment]";
+        String expectedMessage = "Element 'p' is not allowed in 'sym-ai-context'. Allowed elements are: [sym-ai-stream, sym-ai-message, sym-ai-attachment]";
         String actualMessage = exception.getMessage();
         assertTrue(actualMessage.contains(expectedMessage));
     }
 
     @Test
     public void testSymAiContextWithText() {
-        String textChild = "<messageML beta=\"true\"><sym-ai-context>text</sym-ai-context></messageML>";
+        String textChild = "<messageML><sym-ai-context>text</sym-ai-context></messageML>";
 
         Exception exception = assertThrows(InvalidInputException.class, () -> context.parseMessageML(textChild, null, null));
         String expectedMessage = "Element \"sym-ai-context\" may not have text content";
@@ -29,10 +37,10 @@ public class SymAiContextTest extends ElementTest {
 
     @Test
     public void testSymAiContextWithValidChildren() throws Exception {
-        String validChildren = "<messageML beta=\"true\"><sym-ai-context>"
-                + "<stream id=\"stream1\"/>"
-                + "<message id=\"msg1\"/>"
-                + "<attachment streamId=\"stream2\" messageId=\"msg2\" fileId=\"file1\"/>"
+        String validChildren = "<messageML><sym-ai-context>"
+                + "<sym-ai-stream id=\"stream1\"/>"
+                + "<sym-ai-message id=\"msg1\"/>"
+                + "<sym-ai-attachment streamId=\"stream2\" messageId=\"msg2\" fileId=\"file1\"/>"
                 + "</sym-ai-context></messageML>";
         context.parseMessageML(validChildren, null, null);
 
@@ -52,23 +60,14 @@ public class SymAiContextTest extends ElementTest {
 
     @Test
     public void testSymAiContextNotAllowedWithoutBeta() {
+        // Create a context without beta
+        MessageMLContext nonBetaContext = new MessageMLContext(dataProvider);
         String input = "<messageML><sym-ai-context>"
-                + "<stream id=\"stream1\"/>"
+                + "<sym-ai-stream id=\"stream1\"/>"
                 + "</sym-ai-context></messageML>";
 
-        Exception exception = assertThrows(InvalidInputException.class, () -> context.parseMessageML(input, null, null));
-        String expectedMessage = "Element \"sym-ai-context\" is only allowed when messageML has beta=\"true\"";
-        assertEquals(expectedMessage, exception.getMessage());
-    }
-
-    @Test
-    public void testSymAiContextNotAllowedWithBetaFalse() {
-        String input = "<messageML beta=\"false\"><sym-ai-context>"
-                + "<stream id=\"stream1\"/>"
-                + "</sym-ai-context></messageML>";
-
-        Exception exception = assertThrows(InvalidInputException.class, () -> context.parseMessageML(input, null, null));
-        String expectedMessage = "Element \"sym-ai-context\" is only allowed when messageML has beta=\"true\"";
+        Exception exception = assertThrows(InvalidInputException.class, () -> nonBetaContext.parseMessageML(input, null, null));
+        String expectedMessage = "Element \"sym-ai-context\" is only allowed when MessageMLContext is initialized with beta=true";
         assertEquals(expectedMessage, exception.getMessage());
     }
 

--- a/src/test/java/org/finos/symphony/messageml/messagemlutils/elements/SymAiContextTest.java
+++ b/src/test/java/org/finos/symphony/messageml/messagemlutils/elements/SymAiContextTest.java
@@ -12,12 +12,13 @@ public class SymAiContextTest extends ElementTest {
     @Before
     @Override
     public void setUp() {
+        // Create context with beta=true to allow beta attribute on messageML
         context = new MessageMLContext(dataProvider, true);
     }
 
     @Test
     public void testSymAiContextWithInvalidChild() {
-        String invalidChild = "<messageML><sym-ai-context><p>invalid child</p></sym-ai-context></messageML>";
+        String invalidChild = "<messageML beta=\"true\"><sym-ai-context><p>invalid child</p></sym-ai-context></messageML>";
 
         Exception exception = assertThrows(InvalidInputException.class, () -> context.parseMessageML(invalidChild, null, null));
         String expectedMessage = "Element 'p' is not allowed in 'sym-ai-context'. Allowed elements are: [sym-ai-stream, sym-ai-message, sym-ai-attachment]";
@@ -27,7 +28,7 @@ public class SymAiContextTest extends ElementTest {
 
     @Test
     public void testSymAiContextWithText() {
-        String textChild = "<messageML><sym-ai-context>text</sym-ai-context></messageML>";
+        String textChild = "<messageML beta=\"true\"><sym-ai-context>text</sym-ai-context></messageML>";
 
         Exception exception = assertThrows(InvalidInputException.class, () -> context.parseMessageML(textChild, null, null));
         String expectedMessage = "Element \"sym-ai-context\" may not have text content";
@@ -37,7 +38,7 @@ public class SymAiContextTest extends ElementTest {
 
     @Test
     public void testSymAiContextWithValidChildren() throws Exception {
-        String validChildren = "<messageML><sym-ai-context>"
+        String validChildren = "<messageML beta=\"true\"><sym-ai-context>"
                 + "<sym-ai-stream id=\"stream1\"/>"
                 + "<sym-ai-message id=\"msg1\"/>"
                 + "<sym-ai-attachment streamId=\"stream2\" messageId=\"msg2\" fileId=\"file1\"/>"
@@ -59,15 +60,39 @@ public class SymAiContextTest extends ElementTest {
     }
 
     @Test
-    public void testSymAiContextNotAllowedWithoutBeta() {
-        // Create a context without beta
-        MessageMLContext nonBetaContext = new MessageMLContext(dataProvider);
+    public void testSymAiContextNotAllowedWithoutBetaAttribute() {
+        // Context allows beta, but messageML doesn't have beta="true"
         String input = "<messageML><sym-ai-context>"
                 + "<sym-ai-stream id=\"stream1\"/>"
                 + "</sym-ai-context></messageML>";
 
+        Exception exception = assertThrows(InvalidInputException.class, () -> context.parseMessageML(input, null, null));
+        String expectedMessage = "Element \"sym-ai-context\" is only allowed when messageML has beta=\"true\"";
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @Test
+    public void testSymAiContextNotAllowedWithBetaFalse() {
+        // Context allows beta, but messageML has beta="false"
+        String input = "<messageML beta=\"false\"><sym-ai-context>"
+                + "<sym-ai-stream id=\"stream1\"/>"
+                + "</sym-ai-context></messageML>";
+
+        Exception exception = assertThrows(InvalidInputException.class, () -> context.parseMessageML(input, null, null));
+        String expectedMessage = "Element \"sym-ai-context\" is only allowed when messageML has beta=\"true\"";
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @Test
+    public void testBetaAttributeNotAllowedWithoutBetaContext() {
+        // Create a context without beta
+        MessageMLContext nonBetaContext = new MessageMLContext(dataProvider);
+        String input = "<messageML beta=\"true\"><sym-ai-context>"
+                + "<sym-ai-stream id=\"stream1\"/>"
+                + "</sym-ai-context></messageML>";
+
         Exception exception = assertThrows(InvalidInputException.class, () -> nonBetaContext.parseMessageML(input, null, null));
-        String expectedMessage = "Element \"sym-ai-context\" is only allowed when MessageMLContext is initialized with beta=true";
+        String expectedMessage = "Attribute \"beta\" on element \"messageML\" is only allowed when MessageMLContext is initialized with beta=true";
         assertEquals(expectedMessage, exception.getMessage());
     }
 


### PR DESCRIPTION
## Summary

This PR refactors how beta mode is enabled and renames AI-related elements to use the `sym-ai-` prefix.

### Changes

#### Beta Mode via Constructor
- Added a `beta` parameter to `MessageMLContext` constructor instead of using `<messageML beta="true">` attribute
- New constructor: `MessageMLContext(IDataProvider dataProvider, boolean beta)`
- Existing constructor remains backward-compatible with `beta=false` default

#### Element Renames
- `<stream>` → `<sym-ai-stream>`
- `<message>` → `<sym-ai-message>`
- `<attachment>` → `<sym-ai-attachment>`

### Files Modified
- `MessageMLContext.java` - Added beta parameter to constructor
- `MessageMLParser.java` - Accept and propagate beta flag
- `MessageML.java` - Added `setBeta()` method, removed beta attribute handling
- `Stream.java`, `Message.java`, `Attachment.java` - Renamed MESSAGEML_TAG constants
- `SymAiContext.java` - Updated validation error message
- `ElementTest.java`, `SymAiContextTest.java` - Updated tests for new API

### Testing
All 1534 tests pass.